### PR TITLE
Add IAM Instance Profiles and link to EC2 Instances

### DIFF
--- a/altimeter/aws/resource/ec2/instance.py
+++ b/altimeter/aws/resource/ec2/instance.py
@@ -9,6 +9,7 @@ from altimeter.aws.resource.ec2.image import EC2ImageResourceSpec
 from altimeter.aws.resource.ec2.security_group import SecurityGroupResourceSpec
 from altimeter.aws.resource.ec2.subnet import SubnetResourceSpec
 from altimeter.aws.resource.ec2.vpc import VPCResourceSpec
+from altimeter.aws.resource.iam.instance_profile import InstanceProfileResourceSpec
 from altimeter.core.graph.field.dict_field import AnonymousDictField, AnonymousEmbeddedDictField
 from altimeter.core.graph.field.list_field import AnonymousListField
 from altimeter.core.graph.field.resource_link_field import (
@@ -37,6 +38,13 @@ class EC2InstanceResourceSpec(EC2ResourceSpec):
         AnonymousListField(
             "SecurityGroups",
             AnonymousEmbeddedDictField(ResourceLinkField("GroupId", SecurityGroupResourceSpec)),
+        ),
+        AnonymousDictField(
+            "IamInstanceProfile",
+            ResourceLinkField(
+                "Arn", InstanceProfileResourceSpec, alti_key="instance_profile", value_is_id=True
+            ),
+            optional=True,
         ),
         TagsField(),
     )

--- a/altimeter/aws/resource/iam/instance_profile.py
+++ b/altimeter/aws/resource/iam/instance_profile.py
@@ -1,0 +1,47 @@
+"""Resource for Instance Profiles"""
+from typing import Type
+
+from botocore.client import BaseClient
+
+from altimeter.aws.resource.resource_spec import ListFromAWSResult
+from altimeter.aws.resource.iam import IAMResourceSpec
+from altimeter.aws.resource.iam.role import IAMRoleResourceSpec
+from altimeter.core.graph.field.dict_field import AnonymousEmbeddedDictField
+from altimeter.core.graph.field.list_field import AnonymousListField
+from altimeter.core.graph.field.resource_link_field import ResourceLinkField
+from altimeter.core.graph.field.scalar_field import ScalarField
+from altimeter.core.graph.schema import Schema
+
+
+class InstanceProfileResourceSpec(IAMResourceSpec):
+    """Resource for Instance Profiles"""
+
+    type_name = "instance-profile"
+    schema = Schema(
+        ScalarField("InstanceProfileName", alti_key="name"),
+        AnonymousListField(
+            "Roles",
+            AnonymousEmbeddedDictField(
+                ResourceLinkField("Arn", IAMRoleResourceSpec, value_is_id=True)
+            ),
+        ),
+    )
+
+    @classmethod
+    def list_from_aws(
+        cls: Type["InstanceProfileResourceSpec"], client: BaseClient, account_id: str, region: str
+    ) -> ListFromAWSResult:
+        """Return a dict of dicts of the format:
+
+            {'instance_profile_1_arn': {instance_profile_1_dict},
+             'instance_profile_2_arn': {instance_profile_2_dict},
+             ...}
+
+        Where the dicts represent results from list_instance_profiles."""
+        paginator = client.get_paginator("list_instance_profiles")
+        instance_profiles = {}
+        for resp in paginator.paginate():
+            for instance_profile in resp.get("InstanceProfiles", []):
+                resource_arn = instance_profile["Arn"]
+                instance_profiles[resource_arn] = instance_profile
+        return ListFromAWSResult(resources=instance_profiles)

--- a/altimeter/aws/scan/settings.py
+++ b/altimeter/aws/scan/settings.py
@@ -23,6 +23,7 @@ from altimeter.aws.resource.elasticloadbalancing.load_balancer import LoadBalanc
 from altimeter.aws.resource.elasticloadbalancing.target_group import TargetGroupResourceSpec
 from altimeter.aws.resource.events.cloudwatchevents_rule import EventsRuleResourceSpec
 from altimeter.aws.resource.iam.iam_saml_provider import IAMSAMLProviderResourceSpec
+from altimeter.aws.resource.iam.instance_profile import InstanceProfileResourceSpec
 from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec
 from altimeter.aws.resource.iam.role import IAMRoleResourceSpec
 from altimeter.aws.resource.iam.user import IAMUserResourceSpec
@@ -48,6 +49,7 @@ RESOURCE_SPEC_CLASSES: Tuple[Type[AWSResourceSpec], ...] = (
     IAMRoleResourceSpec,
     IAMSAMLProviderResourceSpec,
     IAMUserResourceSpec,
+    InstanceProfileResourceSpec,
     KMSKeyResourceSpec,
     LambdaFunctionResourceSpec,
     LoadBalancerResourceSpec,


### PR DESCRIPTION
Add IAM Instance Profiles, which link to IAM Roles and
add the link from EC2 Instances. Here's a sample SPARQL
query to gather IAM instance profiles and their corresponding
roles for all ec2 instances:

    select ?account_id ?account_name ?region_name ?ec2_instance_id ?instance_profile_name ?iam_role_name
    where
    {
      ?ec2_instance         a                         <alti:aws:ec2:instance> ;
                            <alti:id>                 ?ec2_instance_id ;
                            <alti:account>            ?account ;
                            <alti:region>             ?region .
      ?account              <alti:account_id>         ?account_id ;
                            <alti:name>               ?account_name .
      ?region               <alti:name>               ?region_name

      optional {
          ?ec2_instance     <alti:instance_profile>   ?instance_profile .
          ?instance_profile <alti:role>               ?iam_role ;
                            <alti:name>               ?instance_profile_name .
          ?iam_role         <alti:name>               ?iam_role_name
      }
    }