### PR TITLE
Scan AWS-managed IAM policies

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,6 +63,7 @@ confidence=
 disable=abstract-method,  # doesn't understand ABC
         bad-continuation, # incompatible with black
         invalid-name, # we're ok with things like 'lb' and TypeVars T
+        too-few-public-methods,
 
 #disable=print-statement,
 #        parameter-unpacking,

--- a/altimeter/aws/resource/iam/role.py
+++ b/altimeter/aws/resource/iam/role.py
@@ -101,6 +101,5 @@ def get_attached_role_policies(client: BaseClient, role_name: str) -> List[Dict[
     paginator = client.get_paginator("list_attached_role_policies")
     for resp in paginator.paginate(RoleName=role_name):
         for policy in resp.get("AttachedPolicies", []):
-            if policy["PolicyArn"].split(":")[4] != "aws":  # Include only user-defined Policies
-                policies.append(policy)
+            policies.append(policy)
     return policies

--- a/altimeter/aws/resource/resource_spec.py
+++ b/altimeter/aws/resource/resource_spec.py
@@ -213,17 +213,18 @@ class AWSResourceSpec(ResourceSpec):
                 )
             resource_account_id = arn.split(":")[4]
             if resource_account_id:
-                account_link = ResourceLinkLink(
-                    pred="account", obj=f"arn:aws::::account/{resource_account_id}"
-                )
-                links.append(account_link)
-                resource_region_name = arn.split(":")[3]
-                if resource_region_name:
-                    region_link = ResourceLinkLink(
-                        pred="region",
-                        obj=f"arn:aws:::{resource_account_id}:region/{resource_region_name}",
+                if resource_account_id != "aws":
+                    account_link = ResourceLinkLink(
+                        pred="account", obj=f"arn:aws::::account/{resource_account_id}"
                     )
-                    links.append(region_link)
+                    links.append(account_link)
+                    resource_region_name = arn.split(":")[3]
+                    if resource_region_name:
+                        region_link = ResourceLinkLink(
+                            pred="region",
+                            obj=f"arn:aws:::{resource_account_id}:region/{resource_region_name}",
+                        )
+                        links.append(region_link)
             resource = Resource(resource_id=arn, type_name=cls.get_full_type_name(), links=links)
             resources.append(resource)
         return resources

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -1,56 +1,25 @@
 """An AccountScanner scans a single account using an AccountScanPlan to define scan
 parameters"""
-from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, Future, as_completed
-import time
-import traceback
-from typing import Any, DefaultDict, Dict, List, Tuple, Type
-
-import boto3
+from typing import List
 
 from altimeter.core.artifact_io.writer import ArtifactWriter
-from altimeter.aws.log import AWSLogEvents
-from altimeter.aws.resource.resource_spec import ScanGranularity, AWSResourceSpec
-from altimeter.aws.resource.unscanned_account import UnscannedAccountResourceSpec
-from altimeter.aws.scan.account_scan_plan import AccountScanPlan
-from altimeter.aws.scan.aws_accessor import AWSAccessor
 from altimeter.aws.scan.settings import (
     RESOURCE_SPEC_CLASSES,
     INFRA_RESOURCE_SPEC_CLASSES,
     ORG_RESOURCE_SPEC_CLASSES,
 )
 from altimeter.aws.settings import GRAPH_NAME, GRAPH_VERSION
-from altimeter.core.graph.graph_set import GraphSet
-from altimeter.core.graph.graph_spec import GraphSpec
-from altimeter.core.log import Logger
-from altimeter.core.multilevel_counter import MultilevelCounter
-
-DEFAULT_MAX_SVC_THREADS = 16
+from altimeter.aws.scan.base_scanner import BaseScanner, GetSessionType
 
 
-def get_all_enabled_regions(session: boto3.Session) -> Tuple[str, ...]:
-    """Get all enabled regions -  which are either opted-in or are opt-in-not-required - for
-    a given session.
-    Args:
-        session: boto3 Session
-
-    Returns:
-        tuple of enabled regions in the given session.
-    """
-    client = session.client("ec2")
-    resp: Dict[str, List[Dict[str, str]]] = client.describe_regions(
-        Filters=[{"Name": "opt-in-status", "Values": ["opt-in-not-required", "opted-in"]}]
-    )
-    regions = tuple(region["RegionName"] for region in resp["Regions"])
-    return regions
-
-
-class AccountScanner:
+class AccountScanner(BaseScanner):  # pylint: disable=too-few-public-methods
     """An AccountScanner scans a single account using an AccountScanPlan to define scan parameters
     and writes the output using an ArtifactWriter.
 
     Args:
-        account_scan_plan: AccountScanPlan to scan
+        account_id: account id to scan
+        regions: regions to scan
+        get_session: callable that can get a session in this account_id
         artifact_writer: ArtifactWriter for writing out artifacts
         scan_sub_accounts: if set to True, if this account is an org master any subaccounts
                            of that org will also be scanned.
@@ -61,212 +30,25 @@ class AccountScanner:
 
     def __init__(
         self,
-        account_scan_plan: AccountScanPlan,
+        account_id: str,
+        regions: List[str],
+        get_session: GetSessionType,
         artifact_writer: ArtifactWriter,
         scan_sub_accounts: bool,
         max_svc_threads: int,
         graph_name: str = GRAPH_NAME,
         graph_version: str = GRAPH_VERSION,
     ) -> None:
-        self.account_id = account_scan_plan.account_id
-        self.artifact_writer = artifact_writer
-        self.max_svc_threads = max_svc_threads
-        self.regions = account_scan_plan.regions
-        self.account_scan_plan = account_scan_plan
-        self.get_session = account_scan_plan.get_session
-        self.graph_name = graph_name
-        self.graph_version = graph_version
-        self.resource_spec_classes = RESOURCE_SPEC_CLASSES + INFRA_RESOURCE_SPEC_CLASSES
+        resource_spec_classes = RESOURCE_SPEC_CLASSES + INFRA_RESOURCE_SPEC_CLASSES
         if scan_sub_accounts:
-            self.resource_spec_classes += ORG_RESOURCE_SPEC_CLASSES
-
-    def scan(self) -> Dict[str, Any]:
-        """Scan an account and return a dict containing keys:
-
-            * account_id: str
-            * output_artifact: str
-            * api_call_stats: Dict[str, Any]
-            * errors: List[str]
-
-        If errors is non-empty the results are incomplete for this account.
-        output_artifact is a pointer to the actual scan data - either on the local fs or in s3.
-
-        To scan an account we create a set of GraphSpecs, one for each region.  Any ACCOUNT
-        level granularity resources are only scanned in a single region (e.g. IAM Users)
-
-        Returns:
-            Dict of scan result, see above for details.
-        """
-        logger = Logger()
-        with logger.bind(account_id=self.account_id):
-            logger.info(event=AWSLogEvents.ScanAWSAccountStart)
-            output_artifact = None
-            stats = MultilevelCounter()
-            errors: List[str] = []
-            now = int(time.time())
-            account_graph_set = GraphSet(
-                name=self.graph_name,
-                version=self.graph_version,
-                start_time=now,
-                end_time=now,
-                resources=[],
-                errors=[],
-                stats=stats,
-            )
-            try:
-                # sanity check
-                session = self.get_session()
-                sts_client = session.client("sts")
-                sts_account_id = sts_client.get_caller_identity()["Account"]
-                if sts_account_id != self.account_id:
-                    raise ValueError(
-                        f"BUG: sts detected account_id {sts_account_id} != {self.account_id}"
-                    )
-                if self.regions:
-                    scan_regions = tuple(self.regions)
-                else:
-                    scan_regions = get_all_enabled_regions(session=session)
-                # build graph specs.
-                # build a dict of regions -> services -> List[AWSResourceSpec]
-                regions_services_resource_spec_classes: DefaultDict[
-                    str, DefaultDict[str, List[Type[AWSResourceSpec]]]
-                ] = defaultdict(lambda: defaultdict(list))
-                resource_spec_class: Type[AWSResourceSpec]
-                for resource_spec_class in self.resource_spec_classes:
-                    client_name = resource_spec_class.get_client_name()
-                    resource_class_scan_granularity = resource_spec_class.scan_granularity
-                    if resource_class_scan_granularity == ScanGranularity.ACCOUNT:
-                        regions_services_resource_spec_classes[scan_regions[0]][client_name].append(
-                            resource_spec_class
-                        )
-                    elif resource_class_scan_granularity == ScanGranularity.REGION:
-                        for region in scan_regions:
-                            regions_services_resource_spec_classes[region][client_name].append(
-                                resource_spec_class
-                            )
-                    else:
-                        raise NotImplementedError(
-                            f"ScanGranularity {resource_class_scan_granularity} not implemented"
-                        )
-                with ThreadPoolExecutor(max_workers=self.max_svc_threads) as executor:
-                    futures = []
-                    for (
-                        region,
-                        services_resource_spec_classes,
-                    ) in regions_services_resource_spec_classes.items():
-                        for (
-                            service,
-                            resource_spec_classes,
-                        ) in services_resource_spec_classes.items():
-                            region_session = self.get_session(region=region)
-                            region_creds = region_session.get_credentials()
-                            scan_future = schedule_scan_services(
-                                executor=executor,
-                                graph_name=self.graph_name,
-                                graph_version=self.graph_version,
-                                account_id=self.account_id,
-                                region=region,
-                                service=service,
-                                access_key=region_creds.access_key,
-                                secret_key=region_creds.secret_key,
-                                token=region_creds.token,
-                                resource_spec_classes=tuple(resource_spec_classes),
-                            )
-                            futures.append(scan_future)
-                    for future in as_completed(futures):
-                        graph_set_dict = future.result()
-                        graph_set = GraphSet.from_dict(graph_set_dict)
-                        errors += graph_set.errors
-                        account_graph_set.merge(graph_set)
-                account_graph_set.validate()
-                output_artifact = self.artifact_writer.write_artifact(
-                    name=self.account_id, data=account_graph_set.to_dict()
-                )
-                logger.info(event=AWSLogEvents.ScanAWSAccountEnd)
-            except Exception as ex:
-                error_str = str(ex)
-                trace_back = traceback.format_exc()
-                logger.error(
-                    event=AWSLogEvents.ScanAWSAccountError, error=error_str, trace_back=trace_back
-                )
-                errors.append(" : ".join((error_str, trace_back)))
-                unscanned_account_resource = UnscannedAccountResourceSpec.create_resource(
-                    account_id=self.account_id, errors=errors
-                )
-                failed_account_graph_set = GraphSet(
-                    name=self.graph_name,
-                    version=self.graph_version,
-                    start_time=now,
-                    end_time=now,
-                    resources=[unscanned_account_resource],
-                    errors=errors,
-                    stats=stats,
-                )
-                account_graph_set.merge(failed_account_graph_set)
-        api_call_stats = account_graph_set.stats.to_dict()
-        return {
-            "account_id": self.account_id,
-            "output_artifact": output_artifact,
-            "errors": errors,
-            "api_call_stats": api_call_stats,
-        }
-
-
-def schedule_scan_services(
-    executor: ThreadPoolExecutor,
-    graph_name: str,
-    graph_version: str,
-    account_id: str,
-    region: str,
-    service: str,
-    access_key: str,
-    secret_key: str,
-    token: str,
-    resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
-) -> Future:
-    scan_lambda = lambda: scan_services(
-        graph_name=graph_name,
-        graph_version=graph_version,
-        account_id=account_id,
-        region=region,
-        service=service,
-        access_key=access_key,
-        secret_key=secret_key,
-        token=token,
-        resource_spec_classes=resource_spec_classes,
-    )
-    return executor.submit(scan_lambda)
-
-
-def scan_services(
-    graph_name: str,
-    graph_version: str,
-    account_id: str,
-    region: str,
-    service: str,
-    access_key: str,
-    secret_key: str,
-    token: str,
-    resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
-) -> Dict[str, Any]:
-    logger = Logger()
-    with logger.bind(region=region, service=service):
-        logger.info(event=AWSLogEvents.ScanAWSAccountServiceStart)
-        session = boto3.Session(
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            aws_session_token=token,
-            region_name=region,
-        )
-        aws_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region)
-        graph_spec = GraphSpec(
-            name=graph_name,
-            version=graph_version,
+            resource_spec_classes += ORG_RESOURCE_SPEC_CLASSES
+        super().__init__(
+            account_id=account_id,
+            regions=regions,
+            get_session=get_session,
+            artifact_writer=artifact_writer,
+            max_svc_threads=max_svc_threads,
+            graph_name=graph_name,
+            graph_version=graph_version,
             resource_spec_classes=resource_spec_classes,
-            scan_accessor=aws_accessor,
         )
-        with logger.bind(region=region, service=service):
-            graph_set = graph_spec.scan()
-            graph_set_dict = graph_set.to_dict()
-            logger.info(event=AWSLogEvents.ScanAWSAccountServiceEnd)
-            return graph_set_dict

--- a/altimeter/aws/scan/base_scanner.py
+++ b/altimeter/aws/scan/base_scanner.py
@@ -1,0 +1,271 @@
+"""Base class for classes which scan AWS resources in a single account."""
+import abc
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, Future, as_completed
+import time
+import traceback
+from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Type
+from typing_extensions import Protocol
+
+import boto3
+
+from altimeter.core.artifact_io.writer import ArtifactWriter
+from altimeter.aws.log import AWSLogEvents
+from altimeter.aws.resource.resource_spec import ScanGranularity, AWSResourceSpec
+from altimeter.aws.resource.unscanned_account import UnscannedAccountResourceSpec
+from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.core.graph.graph_set import GraphSet
+from altimeter.core.graph.graph_spec import GraphSpec
+from altimeter.core.log import Logger
+from altimeter.core.multilevel_counter import MultilevelCounter
+
+
+def get_all_enabled_regions(session: boto3.Session) -> Tuple[str, ...]:
+    """Get all enabled regions -  which are either opted-in or are opt-in-not-required - for
+    a given session.
+    Args:
+        session: boto3 Session
+
+    Returns:
+        tuple of enabled regions in the given session.
+    """
+    client = session.client("ec2")
+    resp: Dict[str, List[Dict[str, str]]] = client.describe_regions(
+        Filters=[{"Name": "opt-in-status", "Values": ["opt-in-not-required", "opted-in"]}]
+    )
+    regions = tuple(region["RegionName"] for region in resp["Regions"])
+    return regions
+
+
+class GetSessionType(Protocol):
+    """See https://mypy.readthedocs.io/en/latest/protocols.html#callback-protocols , this
+    is purely for type checking and effectively defines 'GetSessionType' as
+    Callable[[Optional[str]], boto3.Session] which is not possible with Callable"""
+
+    def __call__(self, region: Optional[str] = None) -> boto3.Session:
+        pass
+
+
+class BaseScanner(abc.ABC):
+    """Base class for classes which scan AWS resources in multiple or single accounts.
+
+    Args:
+        account_id: account id to scan
+        regions: regions to scan
+        get_session: callable that can get a session in this account_id
+        artifact_writer: ArtifactWriter for writing out artifacts
+        graph_name: name of graph
+        graph_version: version string for graph
+        max_svc_threads: max number of scan threads to run concurrently.
+        resource_spec_classes: tuple of aws resource spec classes to scan.
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        regions: List[str],
+        get_session: GetSessionType,
+        artifact_writer: ArtifactWriter,
+        max_svc_threads: int,
+        graph_name: str,
+        graph_version: str,
+        resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
+    ) -> None:
+        self.account_id = account_id
+        self.regions = regions
+        self.get_session = get_session
+        self.artifact_writer = artifact_writer
+        self.max_svc_threads = max_svc_threads
+        self.graph_name = graph_name
+        self.graph_version = graph_version
+        self.resource_spec_classes = resource_spec_classes
+
+    def scan(self) -> Dict[str, Any]:
+        """Scan an account and return a dict containing keys:
+
+            * account_id: str
+            * output_artifact: str
+            * api_call_stats: Dict[str, Any]
+            * errors: List[str]
+
+        If errors is non-empty the results are incomplete for this account.
+        output_artifact is a pointer to the actual scan data - either on the local fs or in s3.
+
+        To scan an account we create a set of GraphSpecs, one for each region.  Any ACCOUNT
+        level granularity resources are only scanned in a single region (e.g. IAM Users)
+
+        Returns:
+            Dict of scan result, see above for details.
+        """
+        logger = Logger()
+        with logger.bind(account_id=self.account_id):
+            logger.info(event=AWSLogEvents.ScanAWSAccountStart)
+            output_artifact = None
+            stats = MultilevelCounter()
+            errors: List[str] = []
+            now = int(time.time())
+            account_graph_set = GraphSet(
+                name=self.graph_name,
+                version=self.graph_version,
+                start_time=now,
+                end_time=now,
+                resources=[],
+                errors=[],
+                stats=stats,
+            )
+            try:
+                # sanity check
+                session = self.get_session()
+                sts_client = session.client("sts")
+                sts_account_id = sts_client.get_caller_identity()["Account"]
+                if sts_account_id != self.account_id:
+                    raise ValueError(
+                        f"BUG: sts detected account_id {sts_account_id} != {self.account_id}"
+                    )
+                if self.regions:
+                    scan_regions = tuple(self.regions)
+                else:
+                    scan_regions = get_all_enabled_regions(session=session)
+                # build graph specs.
+                # build a dict of regions -> services -> List[AWSResourceSpec]
+                regions_services_resource_spec_classes: DefaultDict[
+                    str, DefaultDict[str, List[Type[AWSResourceSpec]]]
+                ] = defaultdict(lambda: defaultdict(list))
+                resource_spec_class: Type[AWSResourceSpec]
+                for resource_spec_class in self.resource_spec_classes:
+                    client_name = resource_spec_class.get_client_name()
+                    resource_class_scan_granularity = resource_spec_class.scan_granularity
+                    if resource_class_scan_granularity == ScanGranularity.ACCOUNT:
+                        regions_services_resource_spec_classes[scan_regions[0]][client_name].append(
+                            resource_spec_class
+                        )
+                    elif resource_class_scan_granularity == ScanGranularity.REGION:
+                        for region in scan_regions:
+                            regions_services_resource_spec_classes[region][client_name].append(
+                                resource_spec_class
+                            )
+                    else:
+                        raise NotImplementedError(
+                            f"ScanGranularity {resource_class_scan_granularity} not implemented"
+                        )
+                with ThreadPoolExecutor(max_workers=self.max_svc_threads) as executor:
+                    futures = []
+                    for (
+                        region,
+                        services_resource_spec_classes,
+                    ) in regions_services_resource_spec_classes.items():
+                        for (
+                            service,
+                            resource_spec_classes,
+                        ) in services_resource_spec_classes.items():
+                            region_session = self.get_session(region=region)
+                            region_creds = region_session.get_credentials()
+                            scan_future = schedule_scan_services(
+                                executor=executor,
+                                graph_name=self.graph_name,
+                                graph_version=self.graph_version,
+                                account_id=self.account_id,
+                                region=region,
+                                service=service,
+                                access_key=region_creds.access_key,
+                                secret_key=region_creds.secret_key,
+                                token=region_creds.token,
+                                resource_spec_classes=tuple(resource_spec_classes),
+                            )
+                            futures.append(scan_future)
+                    for future in as_completed(futures):
+                        graph_set_dict = future.result()
+                        graph_set = GraphSet.from_dict(graph_set_dict)
+                        errors += graph_set.errors
+                        account_graph_set.merge(graph_set)
+                account_graph_set.validate()
+                output_artifact = self.artifact_writer.write_artifact(
+                    name=self.account_id, data=account_graph_set.to_dict()
+                )
+                logger.info(event=AWSLogEvents.ScanAWSAccountEnd)
+            except Exception as ex:
+                error_str = str(ex)
+                trace_back = traceback.format_exc()
+                logger.error(
+                    event=AWSLogEvents.ScanAWSAccountError, error=error_str, trace_back=trace_back
+                )
+                errors.append(" : ".join((error_str, trace_back)))
+                unscanned_account_resource = UnscannedAccountResourceSpec.create_resource(
+                    account_id=self.account_id, errors=errors
+                )
+                failed_account_graph_set = GraphSet(
+                    name=self.graph_name,
+                    version=self.graph_version,
+                    start_time=now,
+                    end_time=now,
+                    resources=[unscanned_account_resource],
+                    errors=errors,
+                    stats=stats,
+                )
+                account_graph_set.merge(failed_account_graph_set)
+        api_call_stats = account_graph_set.stats.to_dict()
+        return {
+            "account_id": self.account_id,
+            "output_artifact": output_artifact,
+            "errors": errors,
+            "api_call_stats": api_call_stats,
+        }
+
+
+def schedule_scan_services(
+    executor: ThreadPoolExecutor,
+    graph_name: str,
+    graph_version: str,
+    account_id: str,
+    region: str,
+    service: str,
+    access_key: str,
+    secret_key: str,
+    token: str,
+    resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
+) -> Future:
+    scan_lambda = lambda: scan_services(
+        graph_name=graph_name,
+        graph_version=graph_version,
+        account_id=account_id,
+        region=region,
+        service=service,
+        access_key=access_key,
+        secret_key=secret_key,
+        token=token,
+        resource_spec_classes=resource_spec_classes,
+    )
+    return executor.submit(scan_lambda)
+
+
+def scan_services(
+    graph_name: str,
+    graph_version: str,
+    account_id: str,
+    region: str,
+    service: str,
+    access_key: str,
+    secret_key: str,
+    token: str,
+    resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
+) -> Dict[str, Any]:
+    logger = Logger()
+    with logger.bind(region=region, service=service):
+        logger.info(event=AWSLogEvents.ScanAWSAccountServiceStart)
+        session = boto3.Session(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            aws_session_token=token,
+            region_name=region,
+        )
+        aws_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region)
+        graph_spec = GraphSpec(
+            name=graph_name,
+            version=graph_version,
+            resource_spec_classes=resource_spec_classes,
+            scan_accessor=aws_accessor,
+        )
+        graph_set = graph_spec.scan()
+        graph_set_dict = graph_set.to_dict()
+        logger.info(event=AWSLogEvents.ScanAWSAccountServiceEnd)
+        return graph_set_dict

--- a/altimeter/aws/scan/muxer/local_muxer.py
+++ b/altimeter/aws/scan/muxer/local_muxer.py
@@ -25,7 +25,9 @@ def local_account_scan(
     artifact_writer = FileArtifactWriter(output_dir=output_dir)
     account_scan_plan = AccountScanPlan.from_dict(account_scan_plan_dict=account_scan_plan_dict)
     account_scanner = AccountScanner(
-        account_scan_plan=account_scan_plan,
+        account_id=account_scan_plan.account_id,
+        regions=account_scan_plan.regions,
+        get_session=account_scan_plan.get_session,
         artifact_writer=artifact_writer,
         scan_sub_accounts=scan_sub_accounts,
         max_svc_threads=DEFAULT_MAX_SVC_THREADS,

--- a/altimeter/aws/scan/settings.py
+++ b/altimeter/aws/scan/settings.py
@@ -24,7 +24,7 @@ from altimeter.aws.resource.elasticloadbalancing.target_group import TargetGroup
 from altimeter.aws.resource.events.cloudwatchevents_rule import EventsRuleResourceSpec
 from altimeter.aws.resource.iam.iam_saml_provider import IAMSAMLProviderResourceSpec
 from altimeter.aws.resource.iam.instance_profile import InstanceProfileResourceSpec
-from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec
+from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec, IAMAWSManagedPolicyResourceSpec
 from altimeter.aws.resource.iam.role import IAMRoleResourceSpec
 from altimeter.aws.resource.iam.user import IAMUserResourceSpec
 from altimeter.aws.resource.kms.key import KMSKeyResourceSpec
@@ -45,6 +45,7 @@ RESOURCE_SPEC_CLASSES: Tuple[Type[AWSResourceSpec], ...] = (
     EC2NetworkInterfaceResourceSpec,
     EC2RouteTableResourceSpec,
     EventsRuleResourceSpec,
+    IAMAWSManagedPolicyResourceSpec,
     IAMPolicyResourceSpec,
     IAMRoleResourceSpec,
     IAMSAMLProviderResourceSpec,

--- a/bin/account_scan.py
+++ b/bin/account_scan.py
@@ -19,7 +19,9 @@ def lambda_handler(event, context):
 
     artifact_writer = S3ArtifactWriter(bucket=json_bucket, key_prefix=key_prefix)
     account_scanner = AccountScanner(
-        account_scan_plan=account_scan_plan,
+        account_id=account_scan_plan.account_id,
+        regions=account_scan_plan.regions,
+        get_session=account_scan_plan.get_session,
         artifact_writer=artifact_writer,
         scan_sub_accounts=scan_sub_accounts,
         max_svc_threads=DEFAULT_MAX_SVC_THREADS,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aws-requests-auth==0.4.2
 rdflib==4.2.2
 structlog==18.2.0
 boto3>=1.9.130
+typing-extensions==3.7.4


### PR DESCRIPTION
Add behavior to scan AWS-managed IAM policies.  This scans only the policy names as scanning
policy documents would add 600+ calls for each account.  Ideally we could scan these
exactly once in a single account, however there are some cases where AWS-managed policies
will appear in some accounts and not others - for instance, deprecated policies.  These changes
leave the possibility of scanning the full policies once in addition to the per-account name-only
scans to get a more complete graph.