### PR TITLE
Fix unscannable account behavior

### DIFF
--- a/altimeter/aws/scan/base_scanner.py
+++ b/altimeter/aws/scan/base_scanner.py
@@ -178,6 +178,7 @@ class BaseScanner(abc.ABC):
                         graph_set = GraphSet.from_dict(graph_set_dict)
                         errors += graph_set.errors
                         account_graph_set.merge(graph_set)
+                    account_graph_set.validate()
             except Exception as ex:
                 error_str = str(ex)
                 trace_back = traceback.format_exc()
@@ -197,7 +198,7 @@ class BaseScanner(abc.ABC):
                     errors=errors,
                     stats=stats,
                 )
-        account_graph_set.validate()
+                account_graph_set.validate()
         output_artifact = self.artifact_writer.write_artifact(
             name=self.account_id, data=account_graph_set.to_dict()
         )

--- a/altimeter/core/graph/graph_set.py
+++ b/altimeter/core/graph/graph_set.py
@@ -107,10 +107,7 @@ class GraphSet:
         orphan_refs = resource_ref_ids - present_resource_ids
         if orphan_refs:
             raise GraphSetOrphanedReferencesException(
-                (
-                    "References to resources were found which were not scanned: "
-                    f"{orphan_refs}.\n\nDetails: {json.dumps(resource_ref_ids_used_by_ids)}"
-                )
+                ("References to resources were found which were not scanned: " f"{orphan_refs}.")
             )
 
     def _resolve_duplicates(self) -> None:

--- a/bin/aws2json.py
+++ b/bin/aws2json.py
@@ -249,11 +249,13 @@ def scan(
         account_id = account_scan_manifest.account_id
         if account_scan_manifest.artifacts:
             artifacts += account_scan_manifest.artifacts
-            scanned_accounts.append(account_id)
+            if account_scan_manifest.errors:
+                errors[account_id] = account_scan_manifest.errors
+                unscanned_accounts.append(account_id)
+            else:
+                scanned_accounts.append(account_id)
         else:
             unscanned_accounts.append(account_id)
-        if account_scan_manifest.errors:
-            errors[account_id] = account_scan_manifest.errors
         account_stats = MultilevelCounter.from_dict(account_scan_manifest.api_call_stats)
         stats.merge(account_stats)
     graph_set = None


### PR DESCRIPTION
The desired behavior is to scan either all resources or no resources of an individual
account such that downstream systems can reliably run automated query/remediate
processes.