### PR TITLE
Mark RDS AvailabilityZone field optional.

### DIFF
--- a/altimeter/aws/resource/rds/instance.py
+++ b/altimeter/aws/resource/rds/instance.py
@@ -58,7 +58,7 @@ class RDSInstanceResourceSpec(RDSResourceSpec):
                 ResourceLinkField("VpcSecurityGroupId", SecurityGroupResourceSpec, optional=True)
             ),
         ),
-        ScalarField("AvailabilityZone"),
+        ScalarField("AvailabilityZone", optional=True),
         AnonymousDictField(
             "DBSubnetGroup", ResourceLinkField("VpcId", VPCResourceSpec), optional=True
         ),


### PR DESCRIPTION
This field is sometimes not present if an RDS instance
has DBInstanceStatus == creating.