### PR TITLE
Allows optional Region and Account arguments for generating ARN.

### DIFF
--- a/altimeter/aws/resource/account.py
+++ b/altimeter/aws/resource/account.py
@@ -37,7 +37,7 @@ class AccountResourceSpec(AWSResourceSpec):
 
     @classmethod
     def generate_arn(
-        cls: Type["AccountResourceSpec"], account_id: str, region: str, resource_id: str
+        cls: Type["AccountResourceSpec"], resource_id: str, account_id: str = "", region: str = "",
     ) -> str:
         """Generate an ARN for this resource"""
         return f"arn:aws::::account/{resource_id}"

--- a/altimeter/aws/resource/ec2/image.py
+++ b/altimeter/aws/resource/ec2/image.py
@@ -52,6 +52,8 @@ class EC2ImageResourceSpec(EC2ResourceSpec):
             )
             launch_permissions = perms_resp["LaunchPermissions"]
             image["LaunchPermissions"] = launch_permissions
-            resource_arn = cls.generate_arn(account_id, region, image_id)
+            resource_arn = cls.generate_arn(
+                account_id=account_id, region=region, resource_id=image_id
+            )
             images[resource_arn] = image
         return ListFromAWSResult(resources=images)

--- a/altimeter/aws/resource/ec2/instance.py
+++ b/altimeter/aws/resource/ec2/instance.py
@@ -65,6 +65,8 @@ class EC2InstanceResourceSpec(EC2ResourceSpec):
         for resp in paginator.paginate():
             for reservation in resp.get("Reservations", []):
                 for instance in reservation.get("Instances", []):
-                    resource_arn = cls.generate_arn(account_id, region, instance["InstanceId"])
+                    resource_arn = cls.generate_arn(
+                        account_id=account_id, region=region, resource_id=instance["InstanceId"]
+                    )
                     instances[resource_arn] = instance
         return ListFromAWSResult(resources=instances)

--- a/altimeter/aws/resource/ec2/network_interface.py
+++ b/altimeter/aws/resource/ec2/network_interface.py
@@ -50,6 +50,10 @@ class EC2NetworkInterfaceResourceSpec(EC2ResourceSpec):
         interfaces = {}
         for resp in paginator.paginate():
             for interface in resp.get("NetworkInterfaces", []):
-                resource_arn = cls.generate_arn(account_id, region, interface["NetworkInterfaceId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id,
+                    region=region,
+                    resource_id=interface["NetworkInterfaceId"],
+                )
                 interfaces[resource_arn] = interface
         return ListFromAWSResult(resources=interfaces)

--- a/altimeter/aws/resource/ec2/route_table.py
+++ b/altimeter/aws/resource/ec2/route_table.py
@@ -64,6 +64,8 @@ class EC2RouteTableResourceSpec(EC2ResourceSpec):
         route_tables = {}
         for resp in paginator.paginate():
             for attachment in resp.get("RouteTables", []):
-                resource_arn = cls.generate_arn(account_id, region, attachment["RouteTableId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=attachment["RouteTableId"]
+                )
                 route_tables[resource_arn] = attachment
         return ListFromAWSResult(resources=route_tables)

--- a/altimeter/aws/resource/ec2/security_group.py
+++ b/altimeter/aws/resource/ec2/security_group.py
@@ -116,7 +116,9 @@ class SecurityGroupResourceSpec(EC2ResourceSpec):
         paginator = client.get_paginator("describe_security_groups")
         for resp in paginator.paginate():
             for security_group in resp.get("SecurityGroups", []):
-                resource_arn = cls.generate_arn(account_id, region, security_group["GroupId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=security_group["GroupId"]
+                )
                 for ingress_rule in security_group.get("IpPermissions", []):
                     for ip_range in ingress_rule.get("IpRanges", []):
                         cidr = ip_range["CidrIp"]

--- a/altimeter/aws/resource/ec2/snapshot.py
+++ b/altimeter/aws/resource/ec2/snapshot.py
@@ -43,6 +43,8 @@ class EBSSnapshotResourceSpec(EC2ResourceSpec):
         paginator = client.get_paginator("describe_snapshots")
         for resp in paginator.paginate(OwnerIds=["self"]):
             for snapshot in resp.get("Snapshots", []):
-                resource_arn = cls.generate_arn(account_id, region, snapshot["SnapshotId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=snapshot["SnapshotId"]
+                )
                 snapshots[resource_arn] = snapshot
         return ListFromAWSResult(resources=snapshots)

--- a/altimeter/aws/resource/ec2/subnet.py
+++ b/altimeter/aws/resource/ec2/subnet.py
@@ -33,7 +33,9 @@ class SubnetResourceSpec(EC2ResourceSpec):
         subnets = {}
         resp = client.describe_subnets()
         for subnet in resp.get("Subnets", []):
-            resource_arn = cls.generate_arn(account_id, region, subnet["SubnetId"])
+            resource_arn = cls.generate_arn(
+                account_id=account_id, region=region, resource_id=subnet["SubnetId"]
+            )
             cidr = subnet["CidrBlock"]
             ipv4_network = ipaddress.IPv4Network(cidr, strict=False)
             first_ip, last_ip = int(ipv4_network[0]), int(ipv4_network[-1])

--- a/altimeter/aws/resource/ec2/transit_gateway_vpc_attachment.py
+++ b/altimeter/aws/resource/ec2/transit_gateway_vpc_attachment.py
@@ -38,7 +38,9 @@ class TransitGatewayVpcAttachmentResourceSpec(EC2ResourceSpec):
         for resp in paginator.paginate():
             for attachment in resp.get("TransitGatewayVpcAttachments", []):
                 resource_arn = cls.generate_arn(
-                    account_id, region, attachment["TransitGatewayAttachmentId"]
+                    account_id=account_id,
+                    region=region,
+                    resource_id=attachment["TransitGatewayAttachmentId"],
                 )
                 attachments[resource_arn] = attachment
         return ListFromAWSResult(resources=attachments)

--- a/altimeter/aws/resource/ec2/volume.py
+++ b/altimeter/aws/resource/ec2/volume.py
@@ -56,6 +56,8 @@ class EBSVolumeResourceSpec(EC2ResourceSpec):
         paginator = client.get_paginator("describe_volumes")
         for resp in paginator.paginate():
             for volume in resp.get("Volumes", []):
-                resource_arn = cls.generate_arn(account_id, region, volume["VolumeId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=volume["VolumeId"]
+                )
                 volumes[resource_arn] = volume
         return ListFromAWSResult(resources=volumes)

--- a/altimeter/aws/resource/ec2/vpc.py
+++ b/altimeter/aws/resource/ec2/vpc.py
@@ -33,6 +33,8 @@ class VPCResourceSpec(EC2ResourceSpec):
         paginator = client.get_paginator("describe_vpcs")
         for resp in paginator.paginate():
             for vpc in resp.get("Vpcs", []):
-                resource_arn = cls.generate_arn(account_id, region, vpc["VpcId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=vpc["VpcId"]
+                )
                 vpcs[resource_arn] = vpc
         return ListFromAWSResult(resources=vpcs)

--- a/altimeter/aws/resource/ec2/vpc_endpoint.py
+++ b/altimeter/aws/resource/ec2/vpc_endpoint.py
@@ -39,6 +39,8 @@ class VpcEndpointResourceSpec(EC2ResourceSpec):
         paginator = client.get_paginator("describe_vpc_endpoints")
         for resp in paginator.paginate():
             for endpoint in resp.get("VpcEndpoints", []):
-                resource_arn = cls.generate_arn(account_id, region, endpoint["VpcEndpointId"])
+                resource_arn = cls.generate_arn(
+                    account_id=account_id, region=region, resource_id=endpoint["VpcEndpointId"]
+                )
                 endpoints[resource_arn] = endpoint
         return ListFromAWSResult(resources=endpoints)

--- a/altimeter/aws/resource/resource_spec.py
+++ b/altimeter/aws/resource/resource_spec.py
@@ -100,7 +100,7 @@ class AWSResourceSpec(ResourceSpec):
 
     @classmethod
     def generate_arn(
-        cls: Type["AWSResourceSpec"], account_id: str, region: str, resource_id: str
+        cls: Type["AWSResourceSpec"], resource_id: str, account_id: str = "", region: str = "",
     ) -> str:
         """Generate an ARN for this resource
 

--- a/altimeter/aws/resource/s3/bucket.py
+++ b/altimeter/aws/resource/s3/bucket.py
@@ -78,7 +78,9 @@ class S3BucketResourceSpec(S3ResourceSpec):
                     msg=f"Unable to determine region for {bucket_name}: {s3ade}",
                 )
                 continue
-            resource_arn = cls.generate_arn(account_id, bucket_region, bucket_name)
+            resource_arn = cls.generate_arn(
+                account_id=account_id, region=bucket_region, resource_id=bucket_name
+            )
             try:
                 bucket["Tags"] = get_s3_bucket_tags(client, bucket_name)
             except S3BucketAccessDeniedException as s3ade:

--- a/altimeter/aws/resource/unscanned_account.py
+++ b/altimeter/aws/resource/unscanned_account.py
@@ -47,7 +47,10 @@ class UnscannedAccountResourceSpec(AWSResourceSpec):
 
     @classmethod
     def generate_arn(
-        cls: Type["UnscannedAccountResourceSpec"], account_id: str, region: str, resource_id: str
+        cls: Type["UnscannedAccountResourceSpec"],
+        resource_id: str,
+        account_id: str = "",
+        region: str = "",
     ) -> str:
         """Generate an ARN for this resource"""
         return f"arn:aws::::account/{resource_id}"


### PR DESCRIPTION
- Change to generate_arn method accounts for resources that may not have a region or an account id. 