### PR TITLE
RDS optional field fix

### DIFF
--- a/altimeter/aws/resource/rds/instance.py
+++ b/altimeter/aws/resource/rds/instance.py
@@ -38,7 +38,7 @@ class RDSInstanceResourceSpec(RDSResourceSpec):
         ScalarField("DBName", optional=True),
         AnonymousDictField(
             "Endpoint",
-            ScalarField("Address", alti_key="endpoint_address"),
+            ScalarField("Address", alti_key="endpoint_address", optional=True),
             ScalarField("Port", alti_key="endpoint_port"),
             ScalarField("HostedZoneId", alti_key="endpoint_hosted_zone", optional=True),
             optional=True,


### PR DESCRIPTION
The field Endpoint.Address can disappear when an instance is being
deleted.