### PR TITLE
Additional Parallelism

### DIFF
--- a/altimeter/aws/resource/iam/policy.py
+++ b/altimeter/aws/resource/iam/policy.py
@@ -14,6 +14,7 @@ class IAMPolicyResourceSpec(IAMResourceSpec):
     """Resource for user-managed IAM Policies"""
 
     type_name = "policy"
+    parallel_scan = True
     schema = Schema(
         ScalarField("PolicyName", "name"),
         ScalarField("PolicyId"),

--- a/altimeter/aws/resource/iam/role.py
+++ b/altimeter/aws/resource/iam/role.py
@@ -23,6 +23,7 @@ class IAMRoleResourceSpec(IAMResourceSpec):
     """Resource for IAM Roles"""
 
     type_name = "role"
+    parallel_scan = True
     schema = Schema(
         ScalarField("RoleName", "name"),
         ScalarField("MaxSessionDuration"),

--- a/altimeter/aws/resource/resource_spec.py
+++ b/altimeter/aws/resource/resource_spec.py
@@ -47,6 +47,7 @@ class AWSResourceSpec(ResourceSpec):
     service_name: str = ""
     scan_granularity: ScanGranularity = ScanGranularity.REGION
     region_whitelist: Tuple[str, ...] = ()
+    parallel_scan: bool = False
 
     def __init_subclass__(cls: Type["AWSResourceSpec"], **kwargs: Any) -> None:
         if not inspect.isabstract(cls):

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -326,7 +326,10 @@ class AccountScanner:
 def scan_scan_unit(scan_unit: ScanUnit) -> Tuple[str, Dict[str, Any]]:
     logger = Logger()
     with logger.bind(
-        account_id=scan_unit.account_id, region=scan_unit.region_name, service=scan_unit.service
+        account_id=scan_unit.account_id,
+        region=scan_unit.region_name,
+        service=scan_unit.service,
+        resource_classes=scan_unit.resource_spec_classes,
     ):
         start_t = time.time()
         logger.info(event=AWSLogEvents.ScanAWSAccountServiceStart)

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -179,7 +179,33 @@ class AccountScanner:
                                 service,
                                 svc_resource_spec_classes,
                             ) in shuffled_services_resource_spec_classes:
-                                future = schedule_scan(
+                                parallel_svc_resource_spec_classes = [
+                                    svc_resource_spec_class
+                                    for svc_resource_spec_class in svc_resource_spec_classes
+                                    if svc_resource_spec_class.parallel_scan
+                                ]
+                                serial_svc_resource_spec_classes = [
+                                    svc_resource_spec_class
+                                    for svc_resource_spec_class in svc_resource_spec_classes
+                                    if not svc_resource_spec_class.parallel_scan
+                                ]
+                                for (
+                                    parallel_svc_resource_spec_class
+                                ) in parallel_svc_resource_spec_classes:
+                                    parallel_future = schedule_scan(
+                                        executor=executor,
+                                        graph_name=self.graph_name,
+                                        graph_version=self.graph_version,
+                                        account_id=account_id,
+                                        region_name=region,
+                                        service=service,
+                                        access_key=region_creds.access_key,
+                                        secret_key=region_creds.secret_key,
+                                        token=region_creds.token,
+                                        resource_spec_classes=(parallel_svc_resource_spec_class,),
+                                    )
+                                    futures.append(parallel_future)
+                                serial_future = schedule_scan(
                                     executor=executor,
                                     graph_name=self.graph_name,
                                     graph_version=self.graph_version,
@@ -189,9 +215,9 @@ class AccountScanner:
                                     access_key=region_creds.access_key,
                                     secret_key=region_creds.secret_key,
                                     token=region_creds.token,
-                                    resource_spec_classes=tuple(svc_resource_spec_classes),
+                                    resource_spec_classes=tuple(serial_svc_resource_spec_classes),
                                 )
-                                futures.append(future)
+                                futures.append(serial_future)
                     except Exception as ex:
                         error_str = str(ex)
                         trace_back = traceback.format_exc()

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -329,7 +329,12 @@ def scan_scan_unit(scan_unit: ScanUnit) -> Tuple[str, Dict[str, Any]]:
         account_id=scan_unit.account_id,
         region=scan_unit.region_name,
         service=scan_unit.service,
-        resource_classes=scan_unit.resource_spec_classes,
+        resource_classes=sorted(
+            [
+                resource_spec_class.__name__
+                for resource_spec_class in scan_unit.resource_spec_classes
+            ]
+        ),
     ):
         start_t = time.time()
         logger.info(event=AWSLogEvents.ScanAWSAccountServiceStart)


### PR DESCRIPTION
Currently the unit of scan concurrency is account/region/service. This change adds the ability to scan resource types within an account/region/service concurrently by setting the parallel_scan flag on the resource spec class to True and enables it for iam roles and policies.
