### PR TITLE
Fix unscanned account errors bug

### DIFF
--- a/altimeter/aws/resource/unscanned_account.py
+++ b/altimeter/aws/resource/unscanned_account.py
@@ -26,9 +26,9 @@ class UnscannedAccountResourceSpec(AWSResourceSpec):
     ) -> Resource:
         links: List[Link] = []
         links.append(SimpleLink(pred="account_id", obj=account_id))
-        for error in errors:
-            link = SimpleLink(pred="error", obj=f"{error} - {uuid.uuid4()}")
-            links.append(link)
+        if errors:
+            error = "\n".join(errors)
+            links.append(SimpleLink(pred="error", obj=f"{error} - {uuid.uuid4()}"))
         return Resource(
             resource_id=cls.generate_arn(resource_id=account_id),
             type_name=cls.get_full_type_name(),

--- a/tests/unit/altimeter/aws/resource/test_unscanned_account.py
+++ b/tests/unit/altimeter/aws/resource/test_unscanned_account.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from altimeter.aws.resource.unscanned_account import UnscannedAccountResourceSpec
+from altimeter.core.resource.resource_spec import ResourceSpec
+
+
+class TestUnscannedAccountMultipleErrors(TestCase):
+    def test(self):
+        account_id = "012345678901"
+        errors = ["foo", "boo"]
+        unscanned_account_resource = UnscannedAccountResourceSpec.create_resource(
+            account_id=account_id, errors=errors
+        )
+        resource = ResourceSpec.merge_resources("foo", [unscanned_account_resource])
+
+        resource_dict = resource.to_dict()
+        self.assertEqual(resource_dict["type"], "aws:unscanned-account")
+        self.assertEqual(len(resource_dict["links"]), 2)
+        self.assertEqual(resource_dict["links"][0], {'pred': 'account_id', 'obj': '012345678901', 'type': 'simple'})
+        self.assertEqual(resource_dict["links"][1]["pred"], "error")
+        self.assertEqual(resource_dict["links"][1]["type"], "simple")
+        self.assertTrue(resource_dict["links"][1]["obj"].startswith("foo\nboo - "))


### PR DESCRIPTION
Combine errors into a single link to fix UnmergableDuplicateResource bug which occurs
when an account fails to scan with multiple errors.