### PR TITLE
Allow key prefixes in s3 artifact path

### DIFF
--- a/altimeter/core/artifact_io/reader.py
+++ b/altimeter/core/artifact_io/reader.py
@@ -30,11 +30,7 @@ class ArtifactReader(abc.ABC):
         """Create an ArtifactReader based on an artifact path. This either returns a
         FileArtifactReader or an S3ArtifactReader depending on the value of artifact_path"""
         if is_s3_uri(artifact_path):
-            _, key_prefix = parse_s3_uri(artifact_path)
-            if key_prefix is not None:
-                raise ValueError(
-                    f"S3 artifact path should be s3://<bucket>, no key - got {artifact_path}"
-                )
+            parse_s3_uri(artifact_path)
             return S3ArtifactReader()
         return FileArtifactReader()
 

--- a/altimeter/core/artifact_io/writer.py
+++ b/altimeter/core/artifact_io/writer.py
@@ -56,7 +56,7 @@ class ArtifactWriter(abc.ABC):
         if is_s3_uri(artifact_path):
             bucket, s3_uri_key_prefix = parse_s3_uri(artifact_path)
             if s3_uri_key_prefix is not None:
-                key_prefix = "/".join(s3_uri_key_prefix, scan_id)
+                key_prefix = "/".join((s3_uri_key_prefix, scan_id))
             else:
                 key_prefix = scan_id
             return S3ArtifactWriter(bucket=bucket, key_prefix=key_prefix)

--- a/altimeter/core/artifact_io/writer.py
+++ b/altimeter/core/artifact_io/writer.py
@@ -54,12 +54,12 @@ class ArtifactWriter(abc.ABC):
         """Create an ArtifactWriter based on an artifact path. This either returns a FileArtifactWriter
         or an S3ArtifactWriter depending on the value of artifact_path"""
         if is_s3_uri(artifact_path):
-            bucket, key_prefix = parse_s3_uri(artifact_path)
-            if key_prefix is not None:
-                raise ValueError(
-                    f"S3 artifact path should be s3://<bucket>, no key - got {artifact_path}"
-                )
-            return S3ArtifactWriter(bucket=bucket, key_prefix=scan_id)
+            bucket, s3_uri_key_prefix = parse_s3_uri(artifact_path)
+            if s3_uri_key_prefix is not None:
+                key_prefix = "/".join(s3_uri_key_prefix, scan_id)
+            else:
+                key_prefix = scan_id
+            return S3ArtifactWriter(bucket=bucket, key_prefix=key_prefix)
         return FileArtifactWriter(scan_id=scan_id, output_dir=Path(artifact_path))
 
 

--- a/altimeter/core/config.py
+++ b/altimeter/core/config.py
@@ -66,11 +66,7 @@ class Config(BaseImmutableModel):
         ):
             raise InvalidConfigException("Accessor config not supported for single account mode")
         if is_s3_uri(self.artifact_path):
-            _, key_prefix = parse_s3_uri(self.artifact_path)
-            if key_prefix is not None:
-                raise InvalidConfigException(
-                    f"S3 artifact_path should be s3://<bucket>, no key - got {self.artifact_path}"
-                )
+            parse_s3_uri(self.artifact_path)
 
     @classmethod
     def from_path(cls: Type["Config"], path: str) -> "Config":


### PR DESCRIPTION
This allows crafting s3 lifecycle rules to clean up data files by key prefix.