### PR TITLE
Disable ap-southeast-3 for guardduty

### DIFF
--- a/altimeter/aws/resource/guardduty/__init__.py
+++ b/altimeter/aws/resource/guardduty/__init__.py
@@ -7,3 +7,4 @@ class GuardDutyResourceSpec(AWSResourceSpec):
     """Base class for GuardDuty resources."""
 
     service_name = "guardduty"
+    region_blacklist = ("ap-northeast-3",)

--- a/altimeter/aws/resource/resource_spec.py
+++ b/altimeter/aws/resource/resource_spec.py
@@ -47,6 +47,7 @@ class AWSResourceSpec(ResourceSpec):
     service_name: str = ""
     scan_granularity: ScanGranularity = ScanGranularity.REGION
     region_whitelist: Tuple[str, ...] = ()
+    region_blacklist: Tuple[str, ...] = ()
     parallel_scan: bool = False
 
     def __init_subclass__(cls: Type["AWSResourceSpec"], **kwargs: Any) -> None:

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -153,6 +153,12 @@ class AccountScanner:
                                 )
                                 if not resource_scan_regions:
                                     resource_scan_regions = resource_spec_class.region_whitelist
+                            elif resource_spec_class.region_blacklist:
+                                resource_scan_regions = tuple(
+                                    region
+                                    for region in scan_regions
+                                    if region not in resource_spec_class.region_blacklist
+                                )
                             else:
                                 resource_scan_regions = scan_regions
                             for region in resource_scan_regions:


### PR DESCRIPTION
It appears this region was recently made opt-in-optional and guardduty is not supported in it.