### PR TITLE
Write ListFields to LPG Graphs as multiple Vertices and Edges

### DIFF
--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -138,9 +138,10 @@ class MultiLink(BaseLink):
             "~id": vertex_id,
             "~label": self.pred,
         }
+        edge_label = prefix if prefix != "" else self.pred
         edge = {
             "~id": uuid.uuid1(),
-            "~label": self.pred,
+            "~label": edge_label,
             "~from": parent["~id"],
             "~to": vertex_id,
         }

--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -149,6 +149,7 @@ class MultiLink(BaseLink):
         vertices.append(v)
         self.obj.to_lpg(v, vertices, edges)
 
+
 class ResourceLink(BaseLink):
     """Represents a link to another resource which must exist in the graph."""
 

--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -147,7 +147,7 @@ class MultiLink(BaseLink):
         }
         edges.append(edge)
         vertices.append(v)
-        self.obj.to_lpg(v,vertices, edges)
+        self.obj.to_lpg(v, vertices, edges)
 
 class ResourceLink(BaseLink):
     """Represents a link to another resource which must exist in the graph."""

--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -133,8 +133,20 @@ class MultiLink(BaseLink):
              edges: the list of all edge dictionaries
              prefix: A string to prefix the property name with
         """
-        self.obj.to_lpg(parent, vertices, edges, prefix=self.pred + ".")
-
+        vertex_id = uuid.uuid1()
+        v = {
+            "~id": vertex_id,
+            "~label": self.pred,
+        }
+        edge = {
+            "~id": uuid.uuid1(),
+            "~label": self.pred,
+            "~from": parent["~id"],
+            "~to": vertex_id,
+        }
+        edges.append(edge)
+        vertices.append(v)
+        self.obj.to_lpg(v,vertices, edges)
 
 class ResourceLink(BaseLink):
     """Represents a link to another resource which must exist in the graph."""

--- a/tests/unit/altimeter/core/graph/test_links.py
+++ b/tests/unit/altimeter/core/graph/test_links.py
@@ -184,45 +184,39 @@ class TestMultiLink(unittest.TestCase):
         )
         link = MultiLink(pred=pred, obj=obj)
 
-        parent = {
-            "~id": "parent_id"
-        }
+        parent = {"~id": "parent_id"}
         vertices = []
         edges = []
         link.to_lpg(parent, vertices, edges, "")
 
         expected_vertex = {
-                '~label': 'test-multi-pred',
-                'test-simple-pred-1': 'test-simple-obj-1',
-                'test-simple-pred-2': 'test-simple-obj-2',
-                'test-simple-pred-3': 'test-simple-obj-3',
+            "~label": "test-multi-pred",
+            "test-simple-pred-1": "test-simple-obj-1",
+            "test-simple-pred-2": "test-simple-obj-2",
+            "test-simple-pred-3": "test-simple-obj-3",
         }
 
         self.assertEqual(len(vertices), 1)
-        self.assertIsInstance(vertices[0]['~id'], uuid.UUID)
-        vertex_id = vertices[0]['~id']
-        del vertices[0]['~id']
+        self.assertIsInstance(vertices[0]["~id"], uuid.UUID)
+        vertex_id = vertices[0]["~id"]
+        del vertices[0]["~id"]
         self.assertDictEqual(expected_vertex, vertices[0])
 
-
         expected_edge = {
-                '~label': 'test-multi-pred',
-                '~from': 'parent_id',
-                '~to': vertex_id,
+            "~label": "test-multi-pred",
+            "~from": "parent_id",
+            "~to": vertex_id,
         }
         self.assertEqual(len(edges), 1)
-        self.assertIsInstance(edges[0]['~id'], uuid.UUID)
-        del edges[0]['~id']
+        self.assertIsInstance(edges[0]["~id"], uuid.UUID)
+        del edges[0]["~id"]
         self.assertDictEqual(expected_edge, edges[0])
 
         vertices = []
         edges = []
         link.to_lpg(parent, vertices, edges, "test_prefix")
         self.assertEqual(len(edges), 1)
-        self.assertEqual("test_prefix", edges[0]['~label'])
-
-
-
+        self.assertEqual("test_prefix", edges[0]["~label"])
 
 
 class TestResourceLink(unittest.TestCase):

--- a/tests/unit/altimeter/core/graph/test_links.py
+++ b/tests/unit/altimeter/core/graph/test_links.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 
 from rdflib import BNode, Graph, Literal, Namespace
 from rdflib.term import URIRef
@@ -182,16 +183,46 @@ class TestMultiLink(unittest.TestCase):
             ),
         )
         link = MultiLink(pred=pred, obj=obj)
-        expected_link_dict = {
-            "test-multi-pred.test-simple-pred-1": "test-simple-obj-1",
-            "test-multi-pred.test-simple-pred-2": "test-simple-obj-2",
-            "test-multi-pred.test-simple-pred-3": "test-simple-obj-3",
+
+        parent = {
+            "~id": "parent_id"
         }
-        parent = {}
         vertices = []
         edges = []
         link.to_lpg(parent, vertices, edges, "")
-        self.assertDictEqual(expected_link_dict, parent)
+
+        expected_vertex = {
+                '~label': 'test-multi-pred',
+                'test-simple-pred-1': 'test-simple-obj-1',
+                'test-simple-pred-2': 'test-simple-obj-2',
+                'test-simple-pred-3': 'test-simple-obj-3',
+        }
+
+        self.assertEqual(len(vertices), 1)
+        self.assertIsInstance(vertices[0]['~id'], uuid.UUID)
+        vertex_id = vertices[0]['~id']
+        del vertices[0]['~id']
+        self.assertDictEqual(expected_vertex, vertices[0])
+
+
+        expected_edge = {
+                '~label': 'test-multi-pred',
+                '~from': 'parent_id',
+                '~to': vertex_id,
+        }
+        self.assertEqual(len(edges), 1)
+        self.assertIsInstance(edges[0]['~id'], uuid.UUID)
+        del edges[0]['~id']
+        self.assertDictEqual(expected_edge, edges[0])
+
+        vertices = []
+        edges = []
+        link.to_lpg(parent, vertices, edges, "test_prefix")
+        self.assertEqual(len(edges), 1)
+        self.assertEqual("test_prefix", edges[0]['~label'])
+
+
+
 
 
 class TestResourceLink(unittest.TestCase):


### PR DESCRIPTION
It looks like Altimeter does not write  AWS resources containing ListFields to LPG graphs properly. Concretely the fields are translated as single properties of a vertex so information about the multiple list is lost. 

This PR modifies the method to_lpgof the class: MultiLink so it writes recursively the the list fields as edges plus vertices.