### PR TITLE
Add embedded policies to the Role resource

### DIFF
--- a/altimeter/aws/resource/iam/role.py
+++ b/altimeter/aws/resource/iam/role.py
@@ -43,11 +43,8 @@ class IAMRoleResourceSpec(IAMResourceSpec):
         ),
         ListField(
             "EmbeddedPolicy",
-             EmbeddedDictField(
-                    ScalarField("PolicyName"),
-                    ScalarField("PolicyDocument"),
-                ),
-                optional=True,
+            EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
+            optional=True,
         ),
         DictField(
             "AssumeRolePolicyDocument",
@@ -59,9 +56,9 @@ class IAMRoleResourceSpec(IAMResourceSpec):
                     ListField("Action", EmbeddedScalarField(), allow_scalar=True),
                     DictField(
                         "Principal",
-                        ListField("AWS", EmbeddedScalarField(), optional=True, allow_scalar=True),
+                        ListField("AWS", EmbeddedScalarField(), optional=True, allow_scalar=True,),
                         ListField(
-                            "Federated", EmbeddedScalarField(), optional=True, allow_scalar=True
+                            "Federated", EmbeddedScalarField(), optional=True, allow_scalar=True,
                         ),
                     ),
                 ),
@@ -72,7 +69,7 @@ class IAMRoleResourceSpec(IAMResourceSpec):
 
     @classmethod
     def list_from_aws(
-        cls: Type["IAMRoleResourceSpec"], client: BaseClient, account_id: str, region: str
+        cls: Type["IAMRoleResourceSpec"], client: BaseClient, account_id: str, region: str,
     ) -> ListFromAWSResult:
         """Return a dict of dicts of the format:
 
@@ -98,13 +95,12 @@ class IAMRoleResourceSpec(IAMResourceSpec):
                             if obj_key.lower() == "sts:externalid":
                                 obj[obj_key] = "REMOVED"
                 try:
-                    policies_result = get_attached_role_policies(client, role_name)
-                    policies = policies_result
-                    role["PolicyAttachments"] = policies
+                    attached_policies = get_attached_role_policies(client, role_name)
+                    role["PolicyAttachments"] = attached_policies
                     resource_arn = role["Arn"]
                     roles[resource_arn] = role
-                    policies = get_embedded_role_policies(client, role_name)
-                    role["EmbeddedPolicy"] = policies
+                    embedded_policies = get_embedded_role_policies(client, role_name)
+                    role["EmbeddedPolicy"] = embedded_policies
                 except ClientError as c_e:
                     error_code = getattr(c_e, "response", {}).get("Error", {}).get("Code", {})
                     if error_code != "NoSuchEntity":
@@ -132,11 +128,10 @@ def get_embedded_role_policies(client: BaseClient, role_name: str) -> List[Dict[
             policies.append(policy)
     return policies
 
+
 def get_embedded_role_policy(
-    client: BaseClient,
-    role_name: str,
-    policy_name: str
-    ) -> Dict[str, str]:
+    client: BaseClient, role_name: str, policy_name: str
+) -> Dict[str, str]:
     """Get attached embedded policies"""
     resp = client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
     policy_document = resp.get("PolicyDocument")

--- a/tests/unit/altimeter/aws/resource/iam/test_role.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_role.py
@@ -1,10 +1,12 @@
+import json
+from unittest import TestCase
+from unittest.mock import patch
 import boto3
 from botocore.exceptions import ClientError
-from unittest import TestCase
 from moto import mock_iam
-from unittest.mock import patch
 from altimeter.aws.resource.iam.role import IAMRoleResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.resource.util import policy_doc_dict_to_sorted_str
 
 
 class TestIAMRole(TestCase):
@@ -33,3 +35,94 @@ class TestIAMRole(TestCase):
             )
             resources = IAMRoleResourceSpec.scan(scan_accessor=scan_accessor)
             self.assertEqual(resources, [])
+
+    @mock_iam
+    def test_get_embedded_policy(self):
+        account_id = "123456789012"
+        region_name = "us-east-1"
+        role_name = "foo"
+
+        role_policy = "foo_policy"
+        policy_document = """{
+            "Statement": [
+                {
+                    "Action": ["sts:assumeRole"],
+                    "Effect": "Allow", "Resource": ["*"]
+                }
+            ],
+            "Version": "2012-10-17"
+        }"""
+
+        role_policy2 = "foo_policy2"
+        policy_document2 = """{
+            "Statement": [
+                {
+                    "Action": ["sqs:queue"],
+                    "Effect": "Allow", "Resource": ["*"]
+                }
+            ],
+            "Version": "2012-10-17"
+        }"""
+
+        assume_role_policy_document = """{
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+                }
+            ]
+        }"""
+        session = boto3.Session()
+        client = session.client("iam")
+        client.create_role(RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy_document)
+        iam = boto3.resource('iam')
+        policy = iam.RolePolicy(role_name,role_policy)
+        policy.put(PolicyDocument=policy_document)
+        policy = iam.RolePolicy(role_name,role_policy2)
+        policy.put(PolicyDocument=policy_document2)
+
+        scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
+        resources = IAMRoleResourceSpec.scan(scan_accessor=scan_accessor)
+        embedded_resources_links = [
+            link for link in resources[0].link_collection.multi_links
+            if link.pred == "embedded_policy"
+        ]
+        self.assertEqual(len(embedded_resources_links), 2)
+        # First policy.
+        embedded_resources_link = embedded_resources_links[0]
+        self.assertTrue(compare_embedded_policy(
+            embedded_resources_link,
+            role_policy,
+            policy_document))
+        # Second policy.
+        embedded_resources_link = embedded_resources_links[1]
+        self.assertTrue(compare_embedded_policy(embedded_resources_link, role_policy2, policy_document2))
+
+def compare_embedded_policy(
+    source_policy,
+    expected_policy_name,
+    expected_policy_document
+    ):
+    if source_policy.pred != "embedded_policy":
+        return False
+    if len(source_policy.obj.simple_links) !=  2:
+        return False
+    embedded_policy = source_policy.obj.simple_links[0]
+    if embedded_policy.pred != "policy_name":
+        return False
+    if embedded_policy.obj != expected_policy_name:
+        return False
+    embedded_policy_document = source_policy.obj.simple_links[1]
+    if embedded_policy_document.pred != "policy_document":
+        return False
+    got_policy_document = policy_doc_dict_to_sorted_str(
+        json.loads(embedded_policy_document.obj)
+    )
+    expected_policy_document = policy_doc_dict_to_sorted_str(
+        json.loads(expected_policy_document)
+    )
+    return got_policy_document == expected_policy_document


### PR DESCRIPTION
By now, Altimeter only retrieves the attached policies of a role, but not the embedded ones.
This PR adds a new ListField to IAM role resources named Embedded Policy.
The field is populated with the name and the document text of each embedded policy of the the role.