### PR TITLE
Pin MarkupSafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ jinja2>=2.11.1,<3
 pydantic>=1.6.1,<2
 toml>=0.10.0,<1
 gremlinpython>=3.4.7,<3.5
+
+# Pin version of MarkupSafe to avoid this error:
+# https://github.com/aws/aws-sam-cli/pull/3662
+MarkupSafe>=2.0


### PR DESCRIPTION
Pin the version of the MarkupSafe dependency to avoid using an incompatible version of the library.