### PR TITLE
Allow disabling scanning of resources

### DIFF
--- a/altimeter/aws/aws2n.py
+++ b/altimeter/aws/aws2n.py
@@ -65,7 +65,6 @@ def aws2n(scan_id: str, config: AWSConfig, muxer: AWSScanMuxer, load_neptune: bo
         reader=str(artifact_reader.__class__),
         writer=str(artifact_writer.__class__),
     )
-
     scan_manifest, graph_set = run_scan(
         muxer=muxer,
         config=config,

--- a/altimeter/aws/resource/unscanned_account.py
+++ b/altimeter/aws/resource/unscanned_account.py
@@ -1,5 +1,5 @@
 """Resource representing an unscanned AWS Account"""
-from typing import List, Type
+from typing import List, Tuple, Type
 import uuid
 
 from botocore.client import BaseClient
@@ -8,6 +8,7 @@ from altimeter.core.graph.links import LinkCollection, SimpleLink
 from altimeter.core.graph.schema import Schema
 from altimeter.aws.resource.resource_spec import ScanGranularity, ListFromAWSResult, AWSResourceSpec
 from altimeter.core.resource.resource import Resource
+from altimeter.core.resource.resource_spec import ResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
 
 
@@ -56,6 +57,8 @@ class UnscannedAccountResourceSpec(AWSResourceSpec):
 
     @classmethod
     def scan(
-        cls: Type["UnscannedAccountResourceSpec"], scan_accessor: AWSAccessor
+        cls: Type[AWSResourceSpec],
+        scan_accessor: AWSAccessor,
+        all_resource_spec_classes: Tuple[Type[ResourceSpec], ...],
     ) -> List[Resource]:
         raise NotImplementedError(f"{cls.__name__} is not a scannable ResourceSpec class.")

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -70,6 +70,7 @@ class ScanUnit:
     secret_key: str
     token: str
     resource_spec_classes: Tuple[Type[AWSResourceSpec], ...]
+    all_resource_spec_classes: Tuple[Type[AWSResourceSpec], ...]
 
 
 class AccountScanner:
@@ -182,6 +183,7 @@ class AccountScanner:
                                     secret_key=region_creds.secret_key,
                                     token=region_creds.token,
                                     resource_spec_classes=(parallel_svc_resource_spec_class,),
+                                    all_resource_spec_classes=self.resource_spec_classes,
                                 )
                                 futures.append(parallel_future)
                             serial_future = schedule_scan(
@@ -195,6 +197,7 @@ class AccountScanner:
                                 secret_key=region_creds.secret_key,
                                 token=region_creds.token,
                                 resource_spec_classes=tuple(serial_svc_resource_spec_classes),
+                                all_resource_spec_classes=self.resource_spec_classes,
                             )
                             futures.append(serial_future)
                 except Exception as ex:
@@ -285,6 +288,7 @@ def scan_scan_unit(scan_unit: ScanUnit) -> GraphSet:
             name=scan_unit.graph_name,
             version=scan_unit.graph_version,
             resource_spec_classes=scan_unit.resource_spec_classes,
+            all_resource_spec_classes=scan_unit.all_resource_spec_classes,
             scan_accessor=scan_accessor,
         )
         start_time = int(time.time())
@@ -326,6 +330,7 @@ def schedule_scan(
     secret_key: str,
     token: str,
     resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
+    all_resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
 ) -> Future:
     scan_unit = ScanUnit(
         graph_name=graph_name,
@@ -337,6 +342,7 @@ def schedule_scan(
         secret_key=secret_key,
         token=token,
         resource_spec_classes=resource_spec_classes,
+        all_resource_spec_classes=all_resource_spec_classes,
     )
     future = executor.submit(lambda: scan_scan_unit(scan_unit=scan_unit))
     return future

--- a/altimeter/aws/scan/account_scanner.py
+++ b/altimeter/aws/scan/account_scanner.py
@@ -11,12 +11,11 @@ from typing import DefaultDict, Dict, List, Tuple, Type
 import boto3
 
 from altimeter.aws.log_events import AWSLogEvents
-from altimeter.aws.resource.resource_spec import ScanGranularity, AWSResourceSpec
+from altimeter.aws.resource.resource_spec import AWSResourceSpec
 from altimeter.aws.resource.unscanned_account import UnscannedAccountResourceSpec
 from altimeter.aws.scan.scan_plan import AccountScanPlan
 from altimeter.aws.scan.aws_accessor import AWSAccessor
 from altimeter.aws.scan.settings import (
-    DEFAULT_RESOURCE_SPEC_CLASSES,
     INFRA_RESOURCE_SPEC_CLASSES,
     ORG_RESOURCE_SPEC_CLASSES,
 )
@@ -33,7 +32,7 @@ from altimeter.core.resource.resource import Resource
 
 
 class AccountScanResult(BaseImmutableModel):
-    """pydantic model representing account scan results """
+    """pydantic model representing account scan results"""
 
     account_id: str
     artifacts: List[str]
@@ -90,9 +89,9 @@ class AccountScanner:
         artifact_writer: ArtifactWriter,
         max_svc_scan_threads: int,
         scan_sub_accounts: bool,
+        resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
         graph_name: str = GRAPH_NAME,
         graph_version: str = GRAPH_VERSION,
-        resource_spec_classes: Tuple[Type[AWSResourceSpec], ...] = DEFAULT_RESOURCE_SPEC_CLASSES,
     ) -> None:
         self.account_scan_plan = account_scan_plan
         self.artifact_writer = artifact_writer

--- a/altimeter/aws/scan/muxer/local_muxer.py
+++ b/altimeter/aws/scan/muxer/local_muxer.py
@@ -6,7 +6,6 @@ from altimeter.aws.resource.resource_spec import AWSResourceSpec
 from altimeter.aws.scan.account_scanner import AccountScanner, AccountScanResult
 from altimeter.aws.scan.scan_plan import AccountScanPlan
 from altimeter.aws.scan.muxer import AWSScanMuxer
-from altimeter.aws.scan.settings import DEFAULT_RESOURCE_SPEC_CLASSES
 from altimeter.core.artifact_io.writer import ArtifactWriter
 from altimeter.core.config import AWSConfig
 
@@ -43,7 +42,7 @@ class LocalAWSScanMuxer(AWSScanMuxer):
         self,
         scan_id: str,
         config: AWSConfig,
-        resource_spec_classes: Tuple[Type[AWSResourceSpec], ...] = DEFAULT_RESOURCE_SPEC_CLASSES,
+        resource_spec_classes: Tuple[Type[AWSResourceSpec], ...],
     ):
         super().__init__(scan_id=scan_id, config=config)
         self.resource_spec_classes = resource_spec_classes

--- a/altimeter/core/config.py
+++ b/altimeter/core/config.py
@@ -22,6 +22,7 @@ class ScanConfig(BaseImmutableModel):
     regions: Tuple[str, ...]
     scan_sub_accounts: bool
     preferred_account_scan_regions: Tuple[str, ...]
+    ignored_resources: Tuple[str, ...] = ()
 
 
 class ConcurrencyConfig(BaseImmutableModel):

--- a/altimeter/core/graph/field/resource_link_field.py
+++ b/altimeter/core/graph/field/resource_link_field.py
@@ -22,7 +22,7 @@ class ResourceLinkField(Field):
             >>> class TestResourceSpec(ResourceSpec): type_name="thing"
             >>> input = {"ThingId": "123"}
             >>> field = ResourceLinkField("ThingId", TestResourceSpec)
-            >>> link_collection = field.parse(data=input, context={})
+            >>> link_collection = field.parse(data=input, context={"all_resource_spec_classes": [TestResourceSpec]})
             >>> print(link_collection.dict(exclude_unset=True))
             {'resource_links': ({'pred': 'thing', 'obj': 'thing:123'},)}
 
@@ -31,7 +31,7 @@ class ResourceLinkField(Field):
             >>> class TestResourceSpec(ResourceSpec): type_name="thing"
             >>> input = {"ThingId": "thing:123"}
             >>> field = ResourceLinkField("ThingId", TestResourceSpec, value_is_id=True)
-            >>> link_collection = field.parse(data=input, context={})
+            >>> link_collection = field.parse(data=input, context={"all_resource_spec_classes": [TestResourceSpec]})
             >>> print(link_collection.dict(exclude_unset=True))
             {'resource_links': ({'pred': 'thing', 'obj': 'thing:123'},)}
 
@@ -76,6 +76,9 @@ class ResourceLinkField(Field):
             )
         else:
             resource_spec_class = self._resource_spec_class
+        all_resource_spec_classes = context.get("all_resource_spec_classes", [])
+        if resource_spec_class not in all_resource_spec_classes:
+            return LinkCollection()
         if not self.alti_key:
             self.alti_key = resource_spec_class.type_name
         short_resource_id = data.get(self.source_key)
@@ -110,7 +113,7 @@ class EmbeddedResourceLinkField(SubField):
             >>> class TestResourceSpec(ResourceSpec): type_name="thing"
             >>> input = {"Thing": ["123", "456"]}
             >>> field = ListField("Thing", EmbeddedResourceLinkField(TestResourceSpec))
-            >>> link_collection = field.parse(data=input, context={})
+            >>> link_collection = field.parse(data=input, context={"all_resource_spec_classes": [TestResourceSpec]})
             >>> print(link_collection.dict(exclude_unset=True))
             {'resource_links': ({'pred': 'thing', 'obj': 'thing:123'}, {'pred': 'thing', 'obj': 'thing:456'})}
 
@@ -183,7 +186,7 @@ class TransientResourceLinkField(Field):
             >>> class TestResourceSpec(ResourceSpec): type_name="thing"
             >>> input = {"ThingId": "123"}
             >>> field = TransientResourceLinkField("ThingId", TestResourceSpec)
-            >>> link_collection = field.parse(data=input, context={})
+            >>> link_collection = field.parse(data=input, context={"all_resource_spec_classes": [TestResourceSpec]})
             >>> print(link_collection.dict(exclude_unset=True))
             {'transient_resource_links': ({'pred': 'thing', 'obj': 'thing:123'},)}
     """

--- a/altimeter/core/graph/graph_spec.py
+++ b/altimeter/core/graph/graph_spec.py
@@ -26,11 +26,13 @@ class GraphSpec:
         name: str,
         version: str,
         resource_spec_classes: Tuple[Type[ResourceSpec], ...],
+        all_resource_spec_classes: Tuple[Type[ResourceSpec], ...],
         scan_accessor: Any,
     ):
         self.name = name
         self.version = version
         self.resource_spec_classes = resource_spec_classes
+        self.all_resource_spec_classes = all_resource_spec_classes
         self.scan_accessor = scan_accessor
 
     def scan(self) -> List[Resource]:
@@ -45,7 +47,10 @@ class GraphSpec:
         for resource_spec_class in self.resource_spec_classes:
             with logger.bind(resource_type=str(resource_spec_class.type_name)):
                 logger.debug(event=LogEvent.ScanResourceTypeStart)
-                scanned_resources = resource_spec_class.scan(scan_accessor=self.scan_accessor)
+                scanned_resources = resource_spec_class.scan(
+                    scan_accessor=self.scan_accessor,
+                    all_resource_spec_classes=self.all_resource_spec_classes,
+                )
                 resources += scanned_resources
                 logger.debug(event=LogEvent.ScanResourceTypeEnd)
         return resources

--- a/altimeter/core/graph/schema.py
+++ b/altimeter/core/graph/schema.py
@@ -1,6 +1,6 @@
 """A Schema consists of a list of Fields which define how to parse an arbitrary dictionary
 into a list of Links."""
-from typing import Any, Dict
+from typing import Any, Dict, Tuple, Type
 
 from altimeter.core.graph.field.base import Field
 from altimeter.core.graph.links import LinkCollection
@@ -17,7 +17,7 @@ class Schema:
     def __init__(self, *fields: Field) -> None:
         self.fields = fields
 
-    def parse(self, data: Dict[str, Any], context: Dict[str, Any]) -> LinkCollection:
+    def parse(self, data: Dict[str, Any], context: Dict[str, Any],) -> LinkCollection:
         """Parse this schema into a list of Links
 
         Args:

--- a/altimeter/core/resource/resource_spec.py
+++ b/altimeter/core/resource/resource_spec.py
@@ -48,6 +48,7 @@ class ResourceSpec(abc.ABC):
         Returns:
             List of Resource objects
         """
+        raise Exception("HERE")
 
     @classmethod
     def get_full_type_name(cls: Type["ResourceSpec"]) -> str:

--- a/altimeter/core/resource/resource_spec.py
+++ b/altimeter/core/resource/resource_spec.py
@@ -4,7 +4,7 @@ Fields defining the transformation."""
 import abc
 from collections import defaultdict
 import inspect
-from typing import Any, DefaultDict, Dict, List, Set, Type
+from typing import Any, DefaultDict, Dict, List, Set, Tuple, Type
 
 from altimeter.core.resource.exceptions import (
     MultipleResourceSpecClassesFoundException,
@@ -39,16 +39,20 @@ class ResourceSpec(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def scan(cls: Type["ResourceSpec"], scan_accessor: Any) -> List[Resource]:
+    def scan(
+        cls: Type["ResourceSpec"],
+        scan_accessor: Any,
+        all_resource_spec_classes: Tuple[Type["ResourceSpec"], ...],
+    ) -> List[Resource]:
         """Scan for this ResourceSpec using scan_accessor and return a list of Resource objects
 
         Args:
             scan_accessor: scan accessor object for accessing required APIs
+            all_resource_spec_classes: tuple of all resource spec types which are being scanned by altimeter
 
         Returns:
             List of Resource objects
         """
-        raise Exception("HERE")
 
     @classmethod
     def get_full_type_name(cls: Type["ResourceSpec"]) -> str:

--- a/bin/altimeter_lambda.py
+++ b/bin/altimeter_lambda.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from altimeter.aws.aws2n import AWS2NConfig, generate_scan_id, aws2n
 from altimeter.aws.scan.account_scanner import AccountScanner
 from altimeter.aws.scan.muxer.lambda_muxer import AccountScanLambdaEvent, LambdaAWSScanMuxer
+from altimeter.aws.scan.settings import DEFAULT_RESOURCE_SPEC_CLASSES
 from altimeter.core.artifact_io.writer import ArtifactWriter
 from altimeter.core.config import AWSConfig, GraphPrunerConfig
 from altimeter.core.pruner import prune_graph
@@ -29,6 +30,10 @@ def lambda_handler(event: Dict[str, Any], __: Any) -> Dict[str, Any]:
     try:
         aws2n_config = AWS2NConfig()
         config = AWSConfig.from_path(path=aws2n_config.config_path)
+        if config.scan.ignored_resources:
+            raise NotImplementedError(
+                "The ignored_resources directive is not yet implemented in altimeter_lambda"
+            )
         scan_id = generate_scan_id()
         muxer = LambdaAWSScanMuxer(
             scan_id=scan_id,
@@ -50,6 +55,7 @@ def lambda_handler(event: Dict[str, Any], __: Any) -> Dict[str, Any]:
             artifact_writer=artifact_writer,
             max_svc_scan_threads=account_scan_input.max_svc_scan_threads,
             scan_sub_accounts=account_scan_input.scan_sub_accounts,
+            resource_spec_classes=DEFAULT_RESOURCE_SPEC_CLASSES,
         )
         scan_results = account_scanner.scan()
         return scan_results.dict()

--- a/bin/aws2n.py
+++ b/bin/aws2n.py
@@ -3,10 +3,12 @@
 import argparse
 import os
 import sys
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from altimeter.aws.aws2n import generate_scan_id, aws2n
+from altimeter.aws.resource.resource_spec import AWSResourceSpec
 from altimeter.aws.scan.muxer.local_muxer import LocalAWSScanMuxer
+from altimeter.aws.scan.settings import DEFAULT_RESOURCE_SPEC_CLASSES
 from altimeter.core.config import AWSConfig
 
 
@@ -25,8 +27,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 1
 
     config = AWSConfig.from_path(config)
+    if config.scan.ignored_resources:
+        resource_spec_classes_list: List[Type[AWSResourceSpec]] = []
+        for resource_spec_class in DEFAULT_RESOURCE_SPEC_CLASSES:
+            if resource_spec_class.get_full_type_name() not in config.scan.ignored_resources:
+                resource_spec_classes_list.append(resource_spec_class)
+        resource_spec_classes = tuple(resource_spec_classes_list)
+    else:
+        resource_spec_classes = DEFAULT_RESOURCE_SPEC_CLASSES
     scan_id = generate_scan_id()
-    muxer = LocalAWSScanMuxer(scan_id=scan_id, config=config)
+    muxer = LocalAWSScanMuxer(
+        scan_id=scan_id, config=config, resource_spec_classes=resource_spec_classes,
+    )
     result = aws2n(scan_id=scan_id, config=config, muxer=muxer, load_neptune=False)
     print(result.rdf_path)
     return 0

--- a/bin/aws2neptune.py
+++ b/bin/aws2neptune.py
@@ -2,17 +2,19 @@
 """Graph AWS resource data in Neptune"""
 from datetime import datetime
 import sys
-from typing import List, Optional
+from typing import List, Optional, Type
 import uuid
 import argparse
 import json
 import boto3
 
 from altimeter.aws.log_events import AWSLogEvents
+from altimeter.aws.resource.resource_spec import AWSResourceSpec
 from altimeter.aws.resource_service_region_mapping import build_aws_resource_region_mapping_repo
 from altimeter.aws.scan.muxer import AWSScanMuxer
 from altimeter.aws.scan.muxer.local_muxer import LocalAWSScanMuxer
 from altimeter.aws.scan.scan import run_scan
+from altimeter.aws.scan.settings import DEFAULT_RESOURCE_SPEC_CLASSES
 from altimeter.core.artifact_io.reader import ArtifactReader
 from altimeter.core.artifact_io.writer import ArtifactWriter
 from altimeter.core.config import ConcurrencyConfig, AWSConfig, NeptuneConfig, ScanConfig
@@ -176,8 +178,19 @@ def main(argv: Optional[List[str]] = None) -> int:
         ),
     )
 
+    if config.scan.ignored_resources:
+        resource_spec_classes_list: List[Type[AWSResourceSpec]] = []
+        for resource_spec_class in DEFAULT_RESOURCE_SPEC_CLASSES:
+            if resource_spec_class.get_full_type_name() not in config.scan.ignored_resources:
+                resource_spec_classes_list.append(resource_spec_class)
+        resource_spec_classes = tuple(resource_spec_classes_list)
+    else:
+        resource_spec_classes = DEFAULT_RESOURCE_SPEC_CLASSES
+
     scan_id = generate_scan_id()
-    muxer = LocalAWSScanMuxer(scan_id=scan_id, config=config)
+    muxer = LocalAWSScanMuxer(
+        scan_id=scan_id, config=config, resource_spec_classes=resource_spec_classes
+    )
 
     if config.neptune:
         if bool(config.neptune.use_lpg):

--- a/bin/scan_resource.py
+++ b/bin/scan_resource.py
@@ -48,7 +48,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     sts_client = session.client("sts")
     account_id = sts_client.get_caller_identity()["Account"]
     aws_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region)
-    resource_scan_result = resource_spec_class.scan(aws_accessor)
+    resource_scan_result = resource_spec_class.scan(
+        scan_accessor=aws_accessor, all_resource_spec_classes=DEFAULT_RESOURCE_SPEC_CLASSES,
+    )
     resource_dicts = []
     for resource in resource_scan_result:
         resource_dicts.append(resource.dict())

--- a/conf/current_single_account_skip_iam_policies.toml
+++ b/conf/current_single_account_skip_iam_policies.toml
@@ -11,7 +11,7 @@ pruner_max_age_min = 4320 # prune graphs over 3 days old
     # accounts to scan
     accounts = []
     # regions to scan. If empty, scan all available regions
-    regions = []
+    regions = ["us-east-1"]
     # if true, discover and scan subaccounts of the above accounts
     scan_sub_accounts = false
     # preferred regions to use when scanning non-regional resources (e.g. IAM policies)

--- a/conf/current_single_account_skip_iam_policies.toml
+++ b/conf/current_single_account_skip_iam_policies.toml
@@ -1,0 +1,35 @@
+# This configuration will cause altimeter to scan the currently logged in account.
+
+artifact_path = "/tmp/altimeter_single_account"
+graph_name = "alti"
+pruner_max_age_min = 4320 # prune graphs over 3 days old
+
+[accessor]
+    cache_creds = true
+
+[scan]
+    # accounts to scan
+    accounts = []
+    # regions to scan. If empty, scan all available regions
+    regions = []
+    # if true, discover and scan subaccounts of the above accounts
+    scan_sub_accounts = false
+    # preferred regions to use when scanning non-regional resources (e.g. IAM policies)
+    preferred_account_scan_regions = [
+        "us-west-1",
+        "us-west-2",
+        "us-east-1",
+        "us-east-2",
+    ]
+    # ignore iam policies
+    ignored_resources = [
+        "aws:iam:policy",
+    ]
+
+[concurrency]
+    # The following settings control scan concurrency.
+    #
+    # In general, the maximum number of concurrent scan operations is
+    #   max_account_scan_threads * max_svc_scan_threads
+    max_account_scan_threads = 1            # number of account scan threads to spawn
+    max_svc_scan_threads = 64               # the number of scan threads to spawn in each account scan thread

--- a/tests/unit/altimeter/aws/resource/awslambda/test_function.py
+++ b/tests/unit/altimeter/aws/resource/awslambda/test_function.py
@@ -6,6 +6,7 @@ from moto import mock_ec2, mock_iam, mock_lambda
 
 from altimeter.aws.resource.awslambda.function import LambdaFunctionResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import (
     LinkCollection,
     ResourceLink,
@@ -61,7 +62,9 @@ class TestLambdaFunctionResourceSpec(TestCase):
         )
 
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = LambdaFunctionResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = LambdaFunctionResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
         expected_resources = [
             Resource(
                 resource_id="arn:aws:lambda:us-east-1:123456789012:function:func_name",

--- a/tests/unit/altimeter/aws/resource/dynamodb/test_dynamodb_table.py
+++ b/tests/unit/altimeter/aws/resource/dynamodb/test_dynamodb_table.py
@@ -7,6 +7,7 @@ from moto import mock_dynamodb2
 
 from altimeter.aws.resource.dynamodb.dynamodb_table import DynamoDbTableResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestDynamoDbTableResourceSpec(TestCase):
@@ -38,7 +39,9 @@ class TestDynamoDbTableResourceSpec(TestCase):
                     }
                 },
             )
-            resources = DynamoDbTableResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = DynamoDbTableResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])
 
     @mock_dynamodb2
@@ -69,5 +72,7 @@ class TestDynamoDbTableResourceSpec(TestCase):
                     }
                 },
             )
-            resources = DynamoDbTableResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = DynamoDbTableResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/ec2/test_ec2_route_table.py
+++ b/tests/unit/altimeter/aws/resource/ec2/test_ec2_route_table.py
@@ -1,6 +1,7 @@
 import unittest
 
 from altimeter.aws.resource.ec2.route_table import EC2RouteTableResourceSpec
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import LinkCollection, MultiLink, ResourceLink, SimpleLink
 from altimeter.core.resource.resource import Resource
 
@@ -50,7 +51,12 @@ class TestRouteTableSchema(unittest.TestCase):
         }
 
         link_collection = EC2RouteTableResourceSpec.schema.parse(
-            data=aws_resource_dict, context={"account_id": "111122223333", "region": "us-west-2"}
+            data=aws_resource_dict,
+            context={
+                "account_id": "111122223333",
+                "region": "us-west-2",
+                "all_resource_spec_classes": ALL_RESOURCE_SPEC_CLASSES,
+            },
         )
         resource = Resource(
             resource_id=resource_arn,

--- a/tests/unit/altimeter/aws/resource/ec2/test_volume.py
+++ b/tests/unit/altimeter/aws/resource/ec2/test_volume.py
@@ -5,6 +5,7 @@ from moto import mock_ec2
 
 from altimeter.aws.resource.ec2.volume import EBSVolumeResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import LinkCollection, ResourceLink, SimpleLink
 from altimeter.core.resource.resource import Resource
 
@@ -24,7 +25,9 @@ class TestEBSVolumeResourceSpec(TestCase):
         created_volume_arn = f"arn:aws:ec2:us-east-1:123456789012:volume/{created_volume_id}"
 
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = EBSVolumeResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = EBSVolumeResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
 
         expected_resources = [
             Resource(

--- a/tests/unit/altimeter/aws/resource/ec2/test_vpc.py
+++ b/tests/unit/altimeter/aws/resource/ec2/test_vpc.py
@@ -5,6 +5,7 @@ from moto import mock_ec2
 
 from altimeter.aws.resource.ec2.vpc import VPCResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import LinkCollection, ResourceLink, SimpleLink
 from altimeter.core.resource.resource import Resource
 
@@ -29,7 +30,9 @@ class TestVPCResourceSpec(TestCase):
         created_vpc_arn = f"arn:aws:ec2:us-east-1:123456789012:vpc/{created_vpc_id}"
 
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = VPCResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = VPCResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
 
         expected_resources = [
             Resource(

--- a/tests/unit/altimeter/aws/resource/ec2/test_vpc_endpoint.py
+++ b/tests/unit/altimeter/aws/resource/ec2/test_vpc_endpoint.py
@@ -5,6 +5,7 @@ from dateutil.tz import tzutc
 from altimeter.core.graph.links import LinkCollection, ResourceLink, SimpleLink
 from altimeter.core.resource.resource import Resource
 from altimeter.aws.resource.ec2.vpc_endpoint import VpcEndpointResourceSpec
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestVpcEndpointResourceSpec(unittest.TestCase):
@@ -35,7 +36,12 @@ class TestVpcEndpointResourceSpec(unittest.TestCase):
         }
 
         link_collection = VpcEndpointResourceSpec.schema.parse(
-            data=aws_resource_dict, context={"account_id": "111122223333", "region": "us-west-2"}
+            data=aws_resource_dict,
+            context={
+                "account_id": "111122223333",
+                "region": "us-west-2",
+                "all_resource_spec_classes": ALL_RESOURCE_SPEC_CLASSES,
+            },
         )
         resource = Resource(
             resource_id=resource_arn,

--- a/tests/unit/altimeter/aws/resource/elbv1/test_load_balancer.py
+++ b/tests/unit/altimeter/aws/resource/elbv1/test_load_balancer.py
@@ -5,6 +5,7 @@ from moto import mock_elb
 from unittest.mock import patch
 from altimeter.aws.resource.elbv1.load_balancer import ClassicLoadBalancerResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestLB(TestCase):
@@ -36,5 +37,7 @@ class TestLB(TestCase):
                     }
                 },
             )
-            resources = ClassicLoadBalancerResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = ClassicLoadBalancerResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/elbv2/test_load_balancer.py
+++ b/tests/unit/altimeter/aws/resource/elbv2/test_load_balancer.py
@@ -5,6 +5,7 @@ from moto import mock_ec2, mock_elbv2
 from unittest.mock import patch
 from altimeter.aws.resource.elbv2.load_balancer import LoadBalancerResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestLB(TestCase):
@@ -37,5 +38,7 @@ class TestLB(TestCase):
                     }
                 },
             )
-            resources = LoadBalancerResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = LoadBalancerResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/elbv2/test_target_group.py
+++ b/tests/unit/altimeter/aws/resource/elbv2/test_target_group.py
@@ -5,6 +5,7 @@ from moto import mock_ec2, mock_elbv2
 from unittest.mock import patch
 from altimeter.aws.resource.elbv2.target_group import TargetGroupResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestTargetGroup(TestCase):
@@ -35,5 +36,7 @@ class TestTargetGroup(TestCase):
                     }
                 },
             )
-            resources = TargetGroupResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = TargetGroupResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/events/test_cloudwatchevents_rule.py
+++ b/tests/unit/altimeter/aws/resource/events/test_cloudwatchevents_rule.py
@@ -5,6 +5,7 @@ from moto import mock_events
 from unittest.mock import patch
 from altimeter.aws.resource.events.cloudwatchevents_rule import EventsRuleResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestEventsRule(TestCase):
@@ -36,5 +37,7 @@ class TestEventsRule(TestCase):
                     }
                 },
             )
-            resources = EventsRuleResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = EventsRuleResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/iam/test_group.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_group.py
@@ -5,6 +5,7 @@ from moto import mock_iam
 from unittest.mock import patch
 from altimeter.aws.resource.iam.group import IAMGroupResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestIAMGroup(TestCase):
@@ -33,5 +34,7 @@ class TestIAMGroup(TestCase):
                     }
                 },
             )
-            resources = IAMGroupResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMGroupResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=[ALL_RESOURCE_SPEC_CLASSES],
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/iam/test_oidc_provider.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_oidc_provider.py
@@ -7,6 +7,7 @@ from moto import mock_iam
 
 from altimeter.aws.resource.iam.iam_oidc_provider import IAMOIDCProviderResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import LinkCollection, ResourceLink, SimpleLink
 from altimeter.core.resource.resource import Resource
 
@@ -28,7 +29,9 @@ class TestIAMOIDCProvider(TestCase):
         )
 
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = IAMOIDCProviderResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = IAMOIDCProviderResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
 
         expected_resources = [
             Resource(
@@ -92,5 +95,7 @@ class TestIAMOIDCProvider(TestCase):
                     }
                 },
             )
-            resources = IAMOIDCProviderResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMOIDCProviderResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/iam/test_policy.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_policy.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 from unittest.mock import patch
 from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestIAMPolicy(TestCase):
@@ -41,5 +42,7 @@ class TestIAMPolicy(TestCase):
                     }
                 },
             )
-            resources = IAMPolicyResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMPolicyResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/iam/test_role.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_role.py
@@ -7,6 +7,7 @@ from moto import mock_iam
 from altimeter.aws.resource.iam.role import IAMRoleResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
 from altimeter.aws.resource.util import policy_doc_dict_to_sorted_str
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestIAMRole(TestCase):
@@ -33,7 +34,9 @@ class TestIAMRole(TestCase):
                     }
                 },
             )
-            resources = IAMRoleResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMRoleResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])
 
     @mock_iam
@@ -86,7 +89,9 @@ class TestIAMRole(TestCase):
         policy.put(PolicyDocument=policy_document2)
 
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = IAMRoleResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = IAMRoleResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
         embedded_resources_links = [
             link
             for link in resources[0].link_collection.multi_links

--- a/tests/unit/altimeter/aws/resource/iam/test_saml_provider.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_saml_provider.py
@@ -5,6 +5,7 @@ from moto import mock_iam
 from unittest.mock import patch
 from altimeter.aws.resource.iam.iam_saml_provider import IAMSAMLProviderResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestIAMSAMLProvider(TestCase):
@@ -36,5 +37,7 @@ class TestIAMSAMLProvider(TestCase):
                     }
                 },
             )
-            resources = IAMSAMLProviderResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMSAMLProviderResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/iam/test_user.py
+++ b/tests/unit/altimeter/aws/resource/iam/test_user.py
@@ -5,6 +5,7 @@ from moto import mock_iam
 from unittest.mock import patch
 from altimeter.aws.resource.iam.user import IAMUserResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestIAMUser(TestCase):
@@ -31,7 +32,9 @@ class TestIAMUser(TestCase):
                     }
                 },
             )
-            resources = IAMUserResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMUserResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])
 
     @mock_iam
@@ -53,7 +56,9 @@ class TestIAMUser(TestCase):
                 operation_name="GetAccessKeyLastUsed",
                 error_response={"Error": {"Code": "AccessDenied", "Message": "",}},
             )
-            resources = IAMUserResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMUserResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(len(resources), 1)
             self.assertEqual(resources[0].resource_id, "arn:aws:iam::123456789012:user/foo")
 
@@ -80,7 +85,9 @@ class TestIAMUser(TestCase):
                     }
                 },
             )
-            resources = IAMUserResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMUserResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])
 
     @mock_iam
@@ -106,5 +113,7 @@ class TestIAMUser(TestCase):
                     }
                 },
             )
-            resources = IAMUserResourceSpec.scan(scan_accessor=scan_accessor)
+            resources = IAMUserResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
             self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/rds/test_instance.py
+++ b/tests/unit/altimeter/aws/resource/rds/test_instance.py
@@ -7,6 +7,7 @@ from moto import mock_rds2
 
 from altimeter.aws.resource.rds.instance import RDSInstanceResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 
 
 class TestRDSInstanceResourceSpec(TestCase):
@@ -45,5 +46,8 @@ class TestRDSInstanceResourceSpec(TestCase):
                         }
                     },
                 )
-                resources = RDSInstanceResourceSpec.scan(scan_accessor=scan_accessor)
+                resources = RDSInstanceResourceSpec.scan(
+                    scan_accessor=scan_accessor,
+                    all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+                )
                 self.assertEqual(resources, [])

--- a/tests/unit/altimeter/aws/resource/test_account.py
+++ b/tests/unit/altimeter/aws/resource/test_account.py
@@ -5,6 +5,7 @@ from moto import mock_sts
 
 from altimeter.aws.resource.account import AccountResourceSpec
 from altimeter.aws.scan.aws_accessor import AWSAccessor
+from altimeter.aws.scan.settings import ALL_RESOURCE_SPEC_CLASSES
 from altimeter.core.graph.links import (
     LinkCollection,
     SimpleLink,
@@ -20,7 +21,9 @@ class TestEBSVolumeResourceSpec(TestCase):
 
         session = boto3.Session()
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
-        resources = AccountResourceSpec.scan(scan_accessor=scan_accessor)
+        resources = AccountResourceSpec.scan(
+            scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+        )
 
         expected_resources = [
             Resource(
@@ -42,7 +45,9 @@ class TestEBSVolumeResourceSpec(TestCase):
         session = boto3.Session()
         scan_accessor = AWSAccessor(session=session, account_id=account_id, region_name=region_name)
         with self.assertRaises(ValueError):
-            AccountResourceSpec.scan(scan_accessor=scan_accessor)
+            AccountResourceSpec.scan(
+                scan_accessor=scan_accessor, all_resource_spec_classes=ALL_RESOURCE_SPEC_CLASSES,
+            )
 
     def test_generate_arn(self):
         account_id = "234567890121"

--- a/tests/unit/altimeter/aws/resource/test_resource_spec.py
+++ b/tests/unit/altimeter/aws/resource/test_resource_spec.py
@@ -52,7 +52,7 @@ class TestSkipResourceScanFlag(TestCase):
                 return True
 
         accessor = TestSkipResourceScanFlag.TestAWSAccessor(None, None, None)
-        TestResource.scan(scan_accessor=accessor)
+        TestResource.scan(scan_accessor=accessor, all_resource_spec_classes=[TestResource])
 
     def test_false(self):
         class TestResource(AWSResourceSpec):
@@ -61,4 +61,4 @@ class TestSkipResourceScanFlag(TestCase):
 
         accessor = TestSkipResourceScanFlag.TestAWSAccessor(None, None, None)
         with self.assertRaises(AttributeError):
-            TestResource.scan(scan_accessor=accessor)
+            TestResource.scan(scan_accessor=accessor, all_resource_spec_classes=[TestResource])

--- a/tests/unit/altimeter/core/graph/field/test_resource_link_field.py
+++ b/tests/unit/altimeter/core/graph/field/test_resource_link_field.py
@@ -36,7 +36,9 @@ class TestResourceLinkField(TestCase):
         field = ResourceLinkField("FieldName", TestResourceSpec)
 
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="test_type_name:Value"),),
@@ -48,7 +50,9 @@ class TestResourceLinkField(TestCase):
         field = ResourceLinkField("FieldName", "TestResourceSpec")
 
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="test_type_name:Value"),),
@@ -60,7 +64,9 @@ class TestResourceLinkField(TestCase):
         field = ResourceLinkField("FieldName", TestResourceSpec, alti_key="alti_field_name")
 
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="alti_field_name", obj="test_type_name:Value"),),
@@ -72,7 +78,9 @@ class TestResourceLinkField(TestCase):
         field = ResourceLinkField("FieldName", TestResourceSpec, optional=True)
 
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="test_type_name:Value"),),
@@ -83,7 +91,9 @@ class TestResourceLinkField(TestCase):
         input_str = "{}"
         field = ResourceLinkField("FieldName", TestResourceSpec, optional=True)
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         self.assertEqual(link_collection, LinkCollection())
 
@@ -93,7 +103,7 @@ class TestResourceLinkField(TestCase):
 
         input_data = json.loads(input_str)
         with self.assertRaises(ResourceLinkFieldSourceKeyNotFoundException):
-            field.parse(data=input_data, context={})
+            field.parse(data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)})
 
     def test_value_not_a_string(self):
         input_str = '{"FieldName": [1, 2, 3]}'
@@ -101,13 +111,15 @@ class TestResourceLinkField(TestCase):
 
         input_data = json.loads(input_str)
         with self.assertRaises(ResourceLinkFieldValueNotAStringException):
-            field.parse(data=input_data, context={})
+            field.parse(data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)})
 
     def test_value_is_id(self):
         input_str = '{"FieldName": "Value"}'
         field = ResourceLinkField("FieldName", TestResourceSpec, value_is_id=True)
         input_data = json.loads(input_str)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="Value"),),
@@ -119,7 +131,9 @@ class TestEmbeddedResourceLinkField(TestCase):
     def test_valid_input(self):
         input_data = "foo"
         field = EmbeddedResourceLinkField(TestResourceSpec)
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="test_type_name:foo"),)
@@ -129,7 +143,9 @@ class TestEmbeddedResourceLinkField(TestCase):
     def test_valid_input_str_classname(self):
         input_data = "foo"
         field = EmbeddedResourceLinkField("TestResourceSpec")
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="test_type_name:foo"),),
@@ -140,7 +156,9 @@ class TestEmbeddedResourceLinkField(TestCase):
         input_data = "foo"
         field = EmbeddedResourceLinkField("TestResourceSpec", value_is_id=True)
 
-        link_collection = field.parse(data=input_data, context={})
+        link_collection = field.parse(
+            data=input_data, context={"all_resource_spec_classes": (TestResourceSpec,)}
+        )
 
         expected_link_collection = LinkCollection(
             resource_links=(ResourceLink(pred="test_type_name", obj="foo"),),

--- a/tests/unit/altimeter/core/graph/test_graph_spec.py
+++ b/tests/unit/altimeter/core/graph/test_graph_spec.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Type
+from typing import Any, List, Tuple, Type
 from unittest import TestCase
 
 from altimeter.core.graph.graph_spec import GraphSpec
@@ -15,7 +15,11 @@ class TestResourceSpecA(ResourceSpec):
         return "test:a"
 
     @classmethod
-    def scan(cls: Type["TestResourceSpecA"], scan_accessor: Any) -> List[Resource]:
+    def scan(
+        cls: Type["TestResourceSpecA"],
+        scan_accessor: Any,
+        all_resource_spec_classes: Tuple[Type["ResourceSpec"], ...],
+    ) -> List[Resource]:
         resources = [
             Resource(resource_id="123", type=cls.type_name, link_collection=LinkCollection()),
             Resource(resource_id="456", type=cls.type_name, link_collection=LinkCollection()),
@@ -31,7 +35,11 @@ class TestResourceSpecB(ResourceSpec):
         return "test:b"
 
     @classmethod
-    def scan(cls: Type["TestResourceSpecB"], scan_accessor: Any) -> List[Resource]:
+    def scan(
+        cls: Type["TestResourceSpecB"],
+        scan_accessor: Any,
+        all_resource_spec_classes: Tuple[Type["ResourceSpec"], ...],
+    ) -> List[Resource]:
         resources = [
             Resource(resource_id="abc", type=cls.type_name, link_collection=LinkCollection()),
             Resource(resource_id="def", type=cls.type_name, link_collection=LinkCollection()),
@@ -50,6 +58,7 @@ class TestGraphSpec(TestCase):
             name="test-name",
             version="1",
             resource_spec_classes=(TestResourceSpecA, TestResourceSpecB),
+            all_resource_spec_classes=(TestResourceSpecA, TestResourceSpecB),
             scan_accessor=scan_accessor,
         )
         resources = graph_spec.scan()


### PR DESCRIPTION
By adding a line like

    ignored_resources = [
        "aws:iam:policy",
    ]

to the config altimeter will now skip scanning resource types.

This is only implemented in local mode (not lambda).