### PR TITLE
Use transient resource links for ELB subnets

### DIFF
--- a/altimeter/aws/resource/elbv1/load_balancer.py
+++ b/altimeter/aws/resource/elbv1/load_balancer.py
@@ -15,6 +15,7 @@ from altimeter.core.graph.field.resource_link_field import (
     EmbeddedResourceLinkField,
     ResourceLinkField,
     TransientResourceLinkField,
+    TransientEmbeddedResourceLinkField,
 )
 from altimeter.core.graph.field.list_field import ListField
 from altimeter.core.graph.field.scalar_field import ScalarField
@@ -31,7 +32,7 @@ class ClassicLoadBalancerResourceSpec(ELBV1ResourceSpec):
         ScalarField("LoadBalancerName"),
         ScalarField("Scheme"),
         ResourceLinkField("VPCId", VPCResourceSpec, optional=True),
-        ListField("Subnets", EmbeddedResourceLinkField(SubnetResourceSpec), optional=True),
+        ListField("Subnets", TransientEmbeddedResourceLinkField(SubnetResourceSpec), optional=True),
         ListField(
             "SecurityGroups", EmbeddedResourceLinkField(SecurityGroupResourceSpec), optional=True
         ),

--- a/altimeter/aws/resource/elbv2/load_balancer.py
+++ b/altimeter/aws/resource/elbv2/load_balancer.py
@@ -37,7 +37,7 @@ class LoadBalancerResourceSpec(ELBV2ResourceSpec):
             "AvailabilityZones",
             EmbeddedDictField(
                 ScalarField("ZoneName"),
-                ResourceLinkField("SubnetId", SubnetResourceSpec, optional=True),
+                TransientResourceLinkField("SubnetId", SubnetResourceSpec, optional=True),
                 ListField(
                     "LoadBalancerAddresses",
                     EmbeddedDictField(

--- a/altimeter/core/graph/field/resource_link_field.py
+++ b/altimeter/core/graph/field/resource_link_field.py
@@ -234,3 +234,67 @@ class TransientResourceLinkField(Field):
         return LinkCollection(
             transient_resource_links=[TransientResourceLink(pred=self.alti_key, obj=resource_id)],
         )
+
+
+class TransientEmbeddedResourceLinkField(SubField):
+    """A TransientEmbeddedResourceLinkField is a TransientResourceLinkField where the input is the
+    resource id only, not a key/value where the value is a resource id.
+
+    Examples:
+        A link to a TestResourceSpec resource::
+            >>> from altimeter.core.graph.field.list_field import ListField
+            >>> from altimeter.core.resource.resource_spec import ResourceSpec
+            >>> class TestResourceSpec(ResourceSpec): type_name="thing"
+            >>> input = {"Thing": ["123", "456"]}
+            >>> field = ListField("Thing", TransientEmbeddedResourceLinkField(TestResourceSpec))
+            >>> link_collection = field.parse(data=input, context={})
+            >>> print(link_collection.dict(exclude_unset=True))
+            {'transient_resource_links': ({'pred': 'thing', 'obj': 'thing:123'}, {'pred': 'thing', 'obj': 'thing:456'})}
+
+    Args:
+        resource_spec_class: The name of the ResourceSpec class or the ResourceSpec class which
+                             this link represents.
+        optional: Whether this key is optional. Defaults to False.
+        value_is_id: Whether the value for this key contains the entire resource id. For AWS
+                     resources set this to True if the value is a complete arn.
+    """
+
+    def __init__(
+        self,
+        resource_spec_class: Union[Type[ResourceSpec], str],
+        alti_key: str = None,
+        optional: bool = False,
+        value_is_id: bool = False,
+    ):
+        self._resource_spec_class = resource_spec_class
+        self.alti_key = alti_key
+        self.optional = optional
+        self.value_is_id = value_is_id
+
+    def parse(self, data: str, context: Dict[str, Any]) -> LinkCollection:
+        """Parse this field and return a LinkCollection.
+
+        Args:
+            data: data to parse
+            context: contains data from higher level parsing code.
+
+        Returns:
+            LinkCollection
+        """
+        if isinstance(self._resource_spec_class, str):
+            resource_spec_class: Type[ResourceSpec] = ResourceSpec.get_by_class_name(
+                self._resource_spec_class
+            )
+        else:
+            resource_spec_class = self._resource_spec_class
+        if not self.alti_key:
+            self.alti_key = resource_spec_class.type_name
+
+        short_resource_id = data
+        if self.value_is_id:
+            resource_id = short_resource_id
+        else:
+            resource_id = resource_spec_class.generate_id(short_resource_id, context)
+        return LinkCollection(
+            transient_resource_links=[TransientResourceLink(pred=self.alti_key, obj=resource_id)],
+        )


### PR DESCRIPTION
The subnets linked by an ELB may not exist. However, Altimeter raises a `GraphSetOrphanedReferencesException` exception when validating the resources found after scanning an AWS account that contains ELBs pointing to nonexistent subnets.

This PR changes the ELB subnet resource links to transient resource links. Also, `TransientEmbeddedResourceLinkField` has been created as it was needed by ELBv1.