### PR TITLE
Fix writing the graph to Neptune as an lpg graph

### DIFF
--- a/altimeter/core/graph/graph_set.py
+++ b/altimeter/core/graph/graph_set.py
@@ -155,7 +155,7 @@ class ValidatedGraphSet(GraphSet):
             # Add an edge from each vertex to the metadata vertex
             edges.append(
                 {
-                    "~id": uuid.uuid1(),
+                    "~id": str(uuid.uuid1()),
                     "~label": "identified_resource",
                     "~from": scan_id,
                     "~to": v["~id"],

--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -271,9 +271,14 @@ class TagLink(BaseLink):
              edges: the list of all edge dictionaries
              prefix: string to prefix the property name with
         """
-        if not any(x["~id"] == f"{self.pred}:{self.obj}" for x in vertices):
+
+        id_ = str(self.pred)
+        if str(self.obj) != "":
+            id_ = f"{id_}:{self.obj}"
+
+        if not any(x["~id"] == id_ for x in vertices):
             vertex = {}
-            vertex["~id"] = f"{self.pred}:{self.obj}"
+            vertex["~id"] = id_
             vertex["~label"] = "tag"
             vertex[self.pred] = self.obj
             vertices.append(vertex)
@@ -281,7 +286,7 @@ class TagLink(BaseLink):
             "~id": uuid.uuid1(),
             "~label": "tagged",
             "~from": parent["~id"],
-            "~to": f"{self.pred}:{self.obj}",
+            "~to": id_,
         }
         edges.append(edge)
 

--- a/altimeter/core/neptune/client.py
+++ b/altimeter/core/neptune/client.py
@@ -789,7 +789,7 @@ class AltimeterNeptuneClient:
                         __.addV(self.parse_arn(r["~from"])["resource"])
                         .property(T.id, from_id)
                         .property("scan_id", scan_id)
-                        .property("arn", r["~from"]),
+                        .property("arn", str(r["~from"])),
                     )
                 )
                 .to(
@@ -800,7 +800,7 @@ class AltimeterNeptuneClient:
                         __.addV(self.parse_arn(r["~to"])["resource"])
                         .property(T.id, to_id)
                         .property("scan_id", scan_id)
-                        .property("arn", r["~to"]),
+                        .property("arn", str(r["~to"])),
                     )
                 )
             )


### PR DESCRIPTION
This PR fixes two bugs that were preventing the graph generated by Altimeter to be persisted to the an AWS Neptune database as an ``lpg`` graph. 
Concretely the two problems fixed are:
* AWS Neptune only allows the vertices id's to be of type string, as stated [here](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html) in the section ``Vertex and Edge IDs``
* The method ``parse_arn``of the class ``AltimeterNeptuneClient`` requires for the arn's in the vertices to follow a concrete pattern, but in some cases the id's of the vertices were used as arn's although these id's were not following concrete pattern.