### PR TITLE
Make the field UserId in a Security Group optional

### DIFF
--- a/altimeter/aws/resource/ec2/security_group.py
+++ b/altimeter/aws/resource/ec2/security_group.py
@@ -49,7 +49,7 @@ class SecurityGroupResourceSpec(EC2ResourceSpec):
                     "UserIdGroupPairs",
                     EmbeddedDictField(
                         ResourceLinkField("GroupId", "SecurityGroupResourceSpec"),
-                        ScalarField("UserId", alti_key="account_id"),
+                        ScalarField("UserId", alti_key="account_id", optional=True),
                         ScalarField("PeeringStatus", optional=True),
                         ScalarField("VpcId", optional=True),
                         ScalarField("VpcPeeringConnectionId", optional=True),


### PR DESCRIPTION
PR #167 makes the field `UserId` optional for `IpPermissionsEgress`. However, `IpPermissions` requires the same fix. This PR fixes it.